### PR TITLE
feat: Add get_constraints

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -76,9 +76,6 @@ jobs:
         if: steps.build_cache.outputs['cache-hit'] != 'true'
         run: mix compile
       
-      - name: Formatting
-        run: mix format --check-formatted
-      
       - name: Credo
         run: mix credo --strict
       

--- a/README.md
+++ b/README.md
@@ -57,9 +57,23 @@ Open game at: http://localhost:4000/
 Currently, you need to implement 3 functions to make a game. This will change if we try to add support for different types of games:
 
 ```
+get_constraints(void) -> GameConstraints
 init_game(GameConfig) -> void
 handle_event(LiveEvent) -> Assigns 
 render(Assigns) -> String
+```
+
+#### `get_constraints(void) -> GameConstraints`
+
+Called before initializing the game. This gives GameBox some metadata about the constraints of the game. If you do not implement this function it will assume the min and max players are 2.
+
+
+```rust
+#[derive(Deserialize)]
+struct GameConstraints {
+    min_players: u32,
+    max_players: u32,
+}
 ```
 
 #### `init_game(GameConfig) -> void`

--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -83,8 +83,10 @@ if config_env() == :prod do
     ]
 end
 
-passwd =
-  System.get_env("UPLOAD_PASSWORD") ||
-    raise "UPLOAD_PASSWORD secret not available"
+if config_env() == :prod do
+  passwd =
+    System.get_env("UPLOAD_PASSWORD") ||
+      raise "UPLOAD_PASSWORD secret not available"
 
-config :game_box, password: passwd
+  config :game_box, password: passwd
+end

--- a/lib/game_box/arena.ex
+++ b/lib/game_box/arena.ex
@@ -125,8 +125,9 @@ defmodule GameBox.Arena do
     else
       default = %{
         min_players: 2,
-        max_players: 2,
+        max_players: 2
       }
+
       {:reply, default, arena}
     end
   end

--- a/lib/game_box_web/live/arena_live.ex
+++ b/lib/game_box_web/live/arena_live.ex
@@ -71,9 +71,22 @@ defmodule GameBoxWeb.ArenaLive do
 
     cond do
       num_players < constraints[:min_players] ->
-        {:noreply, put_flash(socket, :error, "Not enough players to start game. Need at least " <> to_string constraints[:min_players])}
+        {:noreply,
+         put_flash(
+           socket,
+           :error,
+           "Not enough players to start game. Need at least " <>
+             to_string(constraints[:min_players])
+         )}
+
       num_players > constraints[:max_players] ->
-        {:noreply, put_flash(socket, :error, "Too many players. Can have no more than " <> to_string constraints[:max_players])}
+        {:noreply,
+         put_flash(
+           socket,
+           :error,
+           "Too many players. Can have no more than " <> to_string(constraints[:max_players])
+         )}
+
       true ->
         :ok = Arena.load_game(arena_id, game_id)
         Arena.broadcast_game_state(%{arena_id: arena_id, version: 0})


### PR DESCRIPTION
Implement get_constraints to tell the GameBox system about how many players you support. This is needed for @nilslice 's game and other games which may have more than 2 or an indeterminate amount of players.