### PR TITLE
feat: use banned user to exclude games

### DIFF
--- a/lib/game_box/games.ex
+++ b/lib/game_box/games.ex
@@ -15,7 +15,10 @@ defmodule GameBox.Games do
 
   @spec list_games :: list(Game.t()) | []
   def list_games do
-    Repo.all(Game)
+    Game
+    |> join(:inner, [g], u in assoc(g, :user), as: :user)
+    |> where([user: user], user.is_banned == false)
+    |> Repo.all()
   end
 
   @spec list_games_for_user(integer()) :: list(Game.t()) | []

--- a/test/game_box/games_test.exs
+++ b/test/game_box/games_test.exs
@@ -19,7 +19,8 @@ defmodule GameBox.GamesTest do
   end
 
   describe "list_games/0" do
-    test "returns all games" do
+    test "returns all games that were not uploaded by a banned user" do
+      _banned_game = insert(:game, user: insert(:user, is_banned: true))
       games = Games.list_games()
       assert Enum.count(games) == 2
     end


### PR DESCRIPTION
connects to #32

- excludes games that belong to banned users from the arena index