### PR TITLE
feat: add arena host logic

### DIFF
--- a/config/test.exs
+++ b/config/test.exs
@@ -23,5 +23,7 @@ config :game_box, GameBoxWeb.Endpoint,
 # Print only warnings and errors during test
 config :logger, level: :warn
 
+config :game_box, disk_volume_path: "test/uploads"
+
 # Initialize plugs at runtime for faster test compilation
 config :phoenix, :plug_init_mode, :runtime

--- a/lib/game_box/arena.ex
+++ b/lib/game_box/arena.ex
@@ -25,6 +25,22 @@ defmodule GameBox.Arena do
     GenServer.cast(via_tuple(arena_id), {:load_game, game_id})
   end
 
+  def get_host(arena_id) do
+    GenServer.call(via_tuple(arena_id), {:get_host, arena_id})
+  end
+
+  def set_host(arena_id, player_id) do
+    GenServer.call(via_tuple(arena_id), {:set_host, player_id})
+  end
+
+  def get_game(arena_id) do
+    GenServer.call(via_tuple(arena_id), {:get_game, arena_id})
+  end
+
+  def set_game(arena_id, game_id) do
+    GenServer.call(via_tuple(arena_id), {:set_game, game_id})
+  end
+
   def render_game(arena_id, assigns) do
     GenServer.call(via_tuple(arena_id), {:extism, "render", assigns})
   end
@@ -87,12 +103,12 @@ defmodule GameBox.Arena do
       {:ok, _pid} ->
         Logger.info("Started game server #{inspect(arena_id)}")
 
-        :ok
+        {:ok, :initiated}
 
       :ignore ->
         Logger.info("Game server #{inspect(arena_id)} already running. Joining")
 
-        :ok
+        {:ok, :joined}
     end
   end
 
@@ -102,7 +118,8 @@ defmodule GameBox.Arena do
      %{
        arena_id: arena_id,
        ctx: Extism.Context.new(),
-       plugin: nil
+       plugin: nil,
+       host_id: nil
      }}
   end
 
@@ -157,6 +174,30 @@ defmodule GameBox.Arena do
   #   PubSub.broadcast(GameBox.PubSub, "arena:#{arena_id}", {:version, version})
   #   {:noreply, state}
   # end
+
+  @impl true
+  def handle_call({:get_host, _arena_id}, _from, state) do
+    {:reply, Map.fetch!(state, :host_id), state}
+  end
+
+  @impl true
+  def handle_call({:set_host, player_id}, _from, state) do
+    {:reply, {:ok, player_id}, Map.put(state, :host_id, player_id)}
+  end
+
+  @impl true
+  def handle_call({:get_game, _arena_id}, _from, state) do
+    {:reply, Map.fetch!(state, :game_id), state}
+  end
+
+  @impl true
+  def handle_call({:set_game, game_id}, _from, state) do
+    %{arena_id: arena_id} = state
+
+    PubSub.broadcast(GameBox.PubSub, "arena:#{arena_id}", :game_selected)
+
+    {:reply, {:ok, game_id}, Map.put(state, :game_id, game_id)}
+  end
 
   @impl true
   def handle_cast({:load_game, game_id}, state) do

--- a/lib/game_box/arena.ex
+++ b/lib/game_box/arena.ex
@@ -119,7 +119,8 @@ defmodule GameBox.Arena do
        arena_id: arena_id,
        ctx: Extism.Context.new(),
        plugin: nil,
-       host_id: nil
+       host_id: nil,
+       game_id: nil
      }}
   end
 

--- a/lib/game_box/games.ex
+++ b/lib/game_box/games.ex
@@ -45,7 +45,7 @@ defmodule GameBox.Games do
       %Game{} = game ->
         {:ok, game}
 
-      result ->
+      _result ->
         {:error, :not_found}
     end
   end

--- a/lib/game_box/games.ex
+++ b/lib/game_box/games.ex
@@ -28,14 +28,25 @@ defmodule GameBox.Games do
     |> Repo.all()
   end
 
-  @spec get_game(integer()) :: {:error, :not_found} | {:ok, Game.t()}
-  def get_game(game_id) do
-    game = Repo.get(Game, game_id)
+  def get_game(game_id) when is_bitstring(game_id) do
+    game_id
+    |> String.to_integer()
+    |> get_game()
+  end
 
-    if is_nil(game) do
-      {:error, :not_found}
-    else
-      {:ok, game}
+  @spec get_game(integer()) :: {:error, :not_found} | {:ok, Game.t()}
+  def get_game(game_id) when is_integer(game_id) do
+    Game
+    |> join(:inner, [g], u in assoc(g, :user), as: :user)
+    |> where([user: user], user.is_banned == false)
+    |> preload([game, user: user], user: user)
+    |> Repo.get(game_id)
+    |> case do
+      %Game{} = game ->
+        {:ok, game}
+
+      result ->
+        {:error, :not_found}
     end
   end
 end

--- a/lib/game_box_web/live/arena_live.ex
+++ b/lib/game_box_web/live/arena_live.ex
@@ -7,46 +7,13 @@ defmodule GameBoxWeb.ArenaLive do
   alias GameBox.Players
   alias Phoenix.PubSub
 
-  def render(assigns) do
-    # NOTE: don't put this in the heex template or it will be cached
-    # ignore warnings from phoenix
-    board = render_board(assigns[:arena][:arena_id], assigns[:current_player][:name])
-
-    ~H"""
-    <%= if board == "" do %>
-      <h1>Arena</h1>
-      <p>Players Online</p>
-      <ul>
-        <li><%= @current_player.name %></li>
-        <li :for={player <- @other_players}>
-          <%= player.name %>
-        </li>
-      </ul>
-
-      <h2>Choose a game to start playing</h2>
-      <ul>
-        <li :for={game <- @games}>
-          <button phx-click="start_game" phx-value-game_id={game.id}><%= game.title %></button>
-        </li>
-      </ul>
-
-      <hr />
-    <% end %>
-
-    <div id="board">
-      <%= Phoenix.HTML.raw(board) %>
-    </div>
-    """
-  end
-
-  def mount(params, _session, socket) do
-    %{"arena_id" => arena_id} = params
-    %{assigns: %{player_id: player_id}} = socket
-
+  def mount(%{"arena_id" => arena_id}, _session, %{assigns: %{player_id: player_id}} = socket) do
     if connected?(socket) do
       PubSub.subscribe(GameBox.PubSub, "arena:#{arena_id}")
       Players.monitor(arena_id, player_id)
     end
+
+    is_host = Arena.get_host(arena_id) == player_id
 
     if Players.exists?(arena_id) and Arena.exists?(arena_id) do
       {:ok,
@@ -55,6 +22,10 @@ defmodule GameBoxWeb.ArenaLive do
        |> assign(:games, Games.list_games())
        |> assign(:version, -1)
        |> assign(:player_id, player_id)
+       |> assign(:is_host, is_host)
+       |> assign(:game_selected, nil)
+       |> assign(:game_started, false)
+       |> assign(:min_players, nil)
        |> assign_current_player()
        |> assign_other_players()}
     else
@@ -62,11 +33,86 @@ defmodule GameBoxWeb.ArenaLive do
     end
   end
 
+  def render(assigns) do
+    # NOTE: don't put this in the heex template or it will be cached
+    # ignore warnings from phoenix
+    board = render_board(assigns[:arena][:arena_id], assigns[:current_player][:name])
+
+    ~H"""
+    <%= if board == "" do %>
+      <h1>Arena: <%= @arena.arena_id %></h1>
+
+      <hr />
+      <h2><%= assigns[:current_player][:name] %></h2>
+      <%= if @is_host && @game_selected do %>
+        <%= if can_start_game?(assigns) do %>
+          <button phx-click="start_game" phx-value-game_id={@game_selected.id}>Start Game</button>
+        <% end %>
+      <% end %>
+      <%= if @is_host && is_nil(@game_selected) do %>
+        <%= if is_nil(@game_selected) do %>
+          <h2>Choose a game to start playing</h2>
+          <ul>
+            <div class="grid grid-cols-4 gap-4">
+              <%= for game <- @games do %>
+                <button phx-click="select_game" phx-value-game_id={game.id}><%= game.title %></button>
+              <% end %>
+            </div>
+          </ul>
+        <% end %>
+      <% end %>
+      <%= if @game_selected && !@game_started do %>
+        <div class="grid grid-cols-2 gap-4">
+          <div>
+            <div>
+              <p>
+                <strong>Player count: </strong>
+                <%= player_count(assigns[:arena][:arena_id]) %>-<%= assigns[:min_players] %>
+              </p>
+            </div>
+            <p>Online Players</p>
+            <ul>
+              <li><%= @current_player.name %></li>
+              <li :for={player <- @other_players}>
+                <%= player.name %>
+              </li>
+            </ul>
+          </div>
+          <div>
+            <p>
+              <strong>Title: </strong>
+              <%= @game_selected.title %>
+            </p>
+            <p><strong>How to play: </strong><%= @game_selected.description %></p>
+            <p><strong>Creator: </strong><%= @game_selected.user.gh_login %></p>
+          </div>
+        </div>
+      <% end %>
+    <% else %>
+      <div id="board">
+        <%= Phoenix.HTML.raw(board) %>
+      </div>
+    <% end %>
+    """
+  end
+
+  def handle_event(
+        "select_game",
+        %{"game_id" => game_id},
+        %{assigns: %{arena: %{arena_id: arena_id}}} = socket
+      ) do
+    case Arena.set_game(arena_id, game_id) do
+      {:ok, _game_id} ->
+        {:noreply, socket}
+
+      _result ->
+        {:noreply, put_flash(socket, :error, "could not select game")}
+    end
+  end
+
   def handle_event("start_game", %{"game_id" => game_id}, socket) do
     %{assigns: %{arena: %{arena_id: arena_id}}} = socket
-    players = Players.list_players(arena_id)
-    num_players = length(Map.keys(players))
-
+    num_players = player_count(arena_id)
     constraints = Arena.get_constraints(arena_id, game_id)
 
     cond do
@@ -124,9 +170,22 @@ defmodule GameBoxWeb.ArenaLive do
   end
 
   def handle_info(:game_started, socket) do
-    # %{assigns: %{arena: %{arena_id: arena_id}, current_player: %{name: player_name}}} = socket
     Logger.info("Game started")
     {:noreply, assign(socket, version: 0)}
+  end
+
+  def handle_info(:game_selected, %{assigns: %{arena: %{arena_id: arena_id}}} = socket) do
+    game_id = Arena.get_game(arena_id)
+    constraints = Arena.get_constraints(arena_id, game_id)
+
+    {:ok, game} = Games.get_game(game_id)
+
+    socket =
+      socket
+      |> assign(:game_selected, game)
+      |> assign(:min_players, constraints[:min_players])
+
+    {:noreply, socket}
   end
 
   def handle_info(:load_game_state, %{assigns: %{server_found?: false}} = socket) do
@@ -166,6 +225,19 @@ defmodule GameBoxWeb.ArenaLive do
 
     assign(socket, :other_players, other_players)
   end
+
+  defp player_count(arena_id) do
+    arena_id
+    |> Players.list_players()
+    |> Map.keys()
+    |> Enum.count()
+  end
+
+  def can_start_game?(%{min_players: min_players, other_players: other_players}) do
+    Enum.count(other_players) + 1 >= min_players
+  end
+
+  def can_start_game?(_), do: false
 
   defp render_board(arena_id, player_id) do
     Arena.render_game(arena_id, %{

--- a/lib/game_box_web/live/arena_live.ex
+++ b/lib/game_box_web/live/arena_live.ex
@@ -30,6 +30,7 @@ defmodule GameBoxWeb.ArenaLive do
         ready? ->
           socket
           |> assign(:game_selected, nil)
+          |> assign(:constraints, %{min_players: 1})
           |> set_defaults(arena_id, player_id)
 
         true ->

--- a/lib/game_box_web/live/home_live.ex
+++ b/lib/game_box_web/live/home_live.ex
@@ -12,21 +12,11 @@ defmodule GameBoxWeb.HomeLive do
       <form id="join_arena" phx-submit="join_arena">
         <div>
           <label for="player_name">Name</label>
-          <input
-            type="text"
-            id="player_name"
-            name="player_name"
-            placeholder="Enter user name"
-          />
+          <input type="text" id="player_name" name="player_name" placeholder="Enter user name" />
         </div>
         <div>
           <label for="arena_id">Arena Code</label>
-          <input
-            type="text"
-            id="arena_id"
-            name="arena_id"
-            placeholder="4 character arena code"
-          />
+          <input type="text" id="arena_id" name="arena_id" placeholder="4 character arena code" />
         </div>
 
         <button type="submit">Join Arena</button>
@@ -41,9 +31,7 @@ defmodule GameBoxWeb.HomeLive do
       Phoenix.PubSub.subscribe(GameBox.PubSub, "games")
     end
 
-    {:ok,
-     socket
-     |> assign(:player_id, session["player_id"])}
+    {:ok, assign(socket, :player_id, session["player_id"])}
   end
 
   @impl true
@@ -55,7 +43,15 @@ defmodule GameBoxWeb.HomeLive do
     else
       %{assigns: %{player_id: player_id}} = socket
       player_params = %{name: player_name, arena_id: arena_id}
-      :ok = Arena.start(arena_id)
+
+      case Arena.start(arena_id) do
+        {:ok, :initiated} ->
+          Arena.set_host(arena_id, player_id)
+
+        {:ok, :joined} ->
+          nil
+      end
+
       :ok = Players.start(arena_id)
 
       case Players.register_player(arena_id, player_id, player_params) do

--- a/test/game_box_web/live/arena_live_test.exs
+++ b/test/game_box_web/live/arena_live_test.exs
@@ -5,7 +5,7 @@ defmodule GameBoxWeb.ArenaLiveTest do
   alias GameBox.Arena
   alias GameBox.Players
 
-  setup ctx do
+  setup do
     path = "tictactoe.wasm"
     disk_volume_path = Application.get_env(:game_box, :disk_volume_path)
     dest = Path.join([disk_volume_path, Path.basename(path)])
@@ -15,41 +15,26 @@ defmodule GameBoxWeb.ArenaLiveTest do
     on_exit(fn ->
       File.rm_rf("test/uploads")
     end)
-
-    %{conn: conn} = ctx
-    game = insert(:game)
-
-    conn2 =
-      Phoenix.ConnTest.build_conn()
-      |> Phoenix.ConnTest.init_test_session(%{player_id: Ecto.UUID.generate()})
-
-    arena_id = "ABCD"
-    player_one_id = get_session(conn, :player_id)
-    player_two_id = get_session(conn2, :player_id)
-
-    Arena.start(arena_id)
-    Arena.set_host(arena_id, player_one_id)
-
-    :ok = Players.start(arena_id)
-
-    Players.update_player(arena_id, player_one_id, %{name: "Test 1"})
-    Players.update_player(arena_id, player_two_id, %{name: "Test 2"})
-
-    {:ok,
-     arena_id: arena_id,
-     conn: conn,
-     conn2: conn2,
-     game: game,
-     player_one_id: player_one_id,
-     player_two_id: player_two_id}
   end
 
   describe "arena" do
-    test "first person to join becomes arena host", %{
-      arena_id: arena_id,
-      conn: conn,
-      conn2: conn2
-    } do
+    test "host can start and select a game", %{conn: conn} do
+      conn2 =
+        Phoenix.ConnTest.build_conn()
+        |> Phoenix.ConnTest.init_test_session(%{player_id: Ecto.UUID.generate()})
+
+      arena_id = "ABCD"
+      player_one_id = get_session(conn, :player_id)
+      player_two_id = get_session(conn2, :player_id)
+
+      Arena.start(arena_id)
+      Arena.set_host(arena_id, player_one_id)
+
+      :ok = Players.start(arena_id)
+
+      Players.update_player(arena_id, player_one_id, %{name: "Test 1"})
+      Players.update_player(arena_id, player_two_id, %{name: "Test 2"})
+
       {:ok, _view1, html1} = live(conn, ~p"/arena/#{arena_id}")
       {:ok, _view2, html2} = live(conn2, ~p"/arena/#{arena_id}")
 
@@ -60,11 +45,26 @@ defmodule GameBoxWeb.ArenaLiveTest do
     end
 
     test "host can select a game", %{
-      arena_id: arena_id,
-      conn: conn,
-      conn2: conn2,
-      game: game
+      conn: conn
     } do
+      game = insert(:game)
+
+      conn2 =
+        Phoenix.ConnTest.build_conn()
+        |> Phoenix.ConnTest.init_test_session(%{player_id: Ecto.UUID.generate()})
+
+      arena_id = "AAAA"
+      player_one_id = get_session(conn, :player_id)
+      player_two_id = get_session(conn2, :player_id)
+
+      Arena.start(arena_id)
+      Arena.set_host(arena_id, player_one_id)
+
+      :ok = Players.start(arena_id)
+
+      Players.update_player(arena_id, player_one_id, %{name: "Test 1"})
+      Players.update_player(arena_id, player_two_id, %{name: "Test 2"})
+
       {:ok, view1, html1} = live(conn, ~p"/arena/#{arena_id}")
       {:ok, view2, html2} = live(conn2, ~p"/arena/#{arena_id}")
 
@@ -86,11 +86,26 @@ defmodule GameBoxWeb.ArenaLiveTest do
     end
 
     test "host can start game", %{
-      arena_id: arena_id,
-      conn: conn,
-      conn2: conn2,
-      game: game
+      conn: conn
     } do
+      game = insert(:game)
+
+      conn2 =
+        Phoenix.ConnTest.build_conn()
+        |> Phoenix.ConnTest.init_test_session(%{player_id: Ecto.UUID.generate()})
+
+      arena_id = "BBBB"
+      player_one_id = get_session(conn, :player_id)
+      player_two_id = get_session(conn2, :player_id)
+
+      Arena.start(arena_id)
+      Arena.set_host(arena_id, player_one_id)
+
+      :ok = Players.start(arena_id)
+
+      Players.update_player(arena_id, player_one_id, %{name: "Test 1"})
+      Players.update_player(arena_id, player_two_id, %{name: "Test 2"})
+
       {:ok, view1, html1} = live(conn, ~p"/arena/#{arena_id}")
       {:ok, _view2, _html2} = live(conn2, ~p"/arena/#{arena_id}")
 

--- a/test/game_box_web/live/arena_live_test.exs
+++ b/test/game_box_web/live/arena_live_test.exs
@@ -1,34 +1,106 @@
 defmodule GameBoxWeb.ArenaLiveTest do
+  @moduledoc false
   use GameBoxWeb.ConnCase
 
   alias GameBox.Arena
   alias GameBox.Players
 
+  setup ctx do
+    path = "tictactoe.wasm"
+    disk_volume_path = Application.get_env(:game_box, :disk_volume_path)
+    dest = Path.join([disk_volume_path, Path.basename(path)])
+    File.mkdir_p(disk_volume_path)
+    File.cp!(path, dest)
+
+    on_exit(fn ->
+      File.rm_rf("test/uploads")
+    end)
+
+    %{conn: conn} = ctx
+    game = insert(:game)
+
+    conn2 =
+      Phoenix.ConnTest.build_conn()
+      |> Phoenix.ConnTest.init_test_session(%{player_id: Ecto.UUID.generate()})
+
+    arena_id = "ABCD"
+    player_one_id = get_session(conn, :player_id)
+    player_two_id = get_session(conn2, :player_id)
+
+    Arena.start(arena_id)
+    Arena.set_host(arena_id, player_one_id)
+
+    :ok = Players.start(arena_id)
+
+    Players.update_player(arena_id, player_one_id, %{name: "Test 1"})
+    Players.update_player(arena_id, player_two_id, %{name: "Test 2"})
+
+    {:ok,
+     arena_id: arena_id,
+     conn: conn,
+     conn2: conn2,
+     game: game,
+     player_one_id: player_one_id,
+     player_two_id: player_two_id}
+  end
+
   describe "arena" do
-    test "shows arena with two players", ctx do
-      %{conn: conn} = ctx
+    test "first person to join becomes arena host", %{
+      arena_id: arena_id,
+      conn: conn,
+      conn2: conn2
+    } do
+      {:ok, _view1, html1} = live(conn, ~p"/arena/#{arena_id}")
+      {:ok, _view2, html2} = live(conn2, ~p"/arena/#{arena_id}")
 
-      conn2 =
-        Phoenix.ConnTest.build_conn()
-        |> Phoenix.ConnTest.init_test_session(%{player_id: Ecto.UUID.generate()})
+      assert html1 =~ "Test 1"
+      assert html1 =~ "Choose a game to start playing"
 
-      arena_id = "CDE"
-      player_one_id = get_session(conn, :player_id)
-      player_two_id = get_session(conn2, :player_id)
+      assert html2 =~ "Test 2"
+    end
 
-      :ok = Players.start(arena_id)
-      :ok = Arena.start(arena_id)
+    test "host can select a game", %{
+      arena_id: arena_id,
+      conn: conn,
+      conn2: conn2,
+      game: game
+    } do
+      {:ok, view1, html1} = live(conn, ~p"/arena/#{arena_id}")
+      {:ok, view2, html2} = live(conn2, ~p"/arena/#{arena_id}")
 
-      Players.update_player(arena_id, player_one_id, %{name: "Test 1"})
-      Players.update_player(arena_id, player_two_id, %{name: "Test 2"})
+      assert html1 =~ game.title
+      assert html1 =~ "Choose a game to start playing"
+      refute html2 =~ game.title
+      refute html2 =~ "Choose a game to start playing"
 
-      {:ok, view1, _html} = live(conn, ~p"/arena/#{arena_id}")
-      live(conn2, ~p"/arena/#{arena_id}")
+      render_click(view1, :select_game, %{"game_id" => game.id})
 
-      html = render(view1)
+      html1 = render(view1)
+      html2 = render(view2)
 
-      assert html =~ "Test 1"
-      assert html =~ "Test 2"
+      assert html1 =~ game.description
+      assert html2 =~ game.description
+
+      assert html1 =~ "Start Game"
+      refute html2 =~ "Start Game"
+    end
+
+    test "host can start game", %{
+      arena_id: arena_id,
+      conn: conn,
+      conn2: conn2,
+      game: game
+    } do
+      {:ok, view1, html1} = live(conn, ~p"/arena/#{arena_id}")
+      {:ok, _view2, _html2} = live(conn2, ~p"/arena/#{arena_id}")
+
+      assert html1 =~ game.title
+      assert html1 =~ "Choose a game to start playing"
+
+      render_click(view1, :select_game, %{"game_id" => game.id})
+      render_click(view1, :start_game, %{"game_id" => game.id})
+
+      refute render(view1) =~ "Start Game"
     end
   end
 end

--- a/test/game_box_web/live/upload_live_test.exs
+++ b/test/game_box_web/live/upload_live_test.exs
@@ -38,8 +38,15 @@ defmodule GameBoxWeb.UploadLiveTest do
         |> assign(:current_user, user)
         |> put_session(:user_id, user.id)
 
-      # We need to create this directory because it is gitignored
-      File.mkdir_p("priv/static/uploads")
+      path = "tictactoe.wasm"
+      disk_volume_path = Application.get_env(:game_box, :disk_volume_path)
+      dest = Path.join([disk_volume_path, Path.basename(path)])
+      File.mkdir_p(disk_volume_path)
+      File.cp!(path, dest)
+
+      on_exit(fn ->
+        File.rm_rf("test/uploads")
+      end)
 
       {:ok, conn: conn}
     end

--- a/test/support/factory.ex
+++ b/test/support/factory.ex
@@ -33,7 +33,7 @@ defmodule GameBox.Factory do
     %GameBox.Games.Game{
       title: sequence(:title, &"Game #{&1}"),
       description: "a very fun game to play!",
-      path: "uploaded_path/123",
+      path: "tictactoe.wasm",
       user: build(:user)
     }
   end


### PR DESCRIPTION
feat: 
- adds logic for the first player to join an arena to be crowned the host
- the host is allowed to select and start a game.

fix
- adds a way for returning players to enter the same arena with/without a name change 