### PR TITLE
fix: use get env for correct path

### DIFF
--- a/lib/game_box_web/live/upload_live.ex
+++ b/lib/game_box_web/live/upload_live.ex
@@ -4,7 +4,6 @@ defmodule GameBoxWeb.UploadLive do
   alias GameBox.Games
   alias GameBox.Games.Game
 
-  @disk_volume_path Application.compile_env(:game_box, :disk_volume_path)
   @max_file_size 100_000_000
 
   @impl true
@@ -119,8 +118,10 @@ defmodule GameBoxWeb.UploadLive do
   end
 
   defp handle_consume(socket, atom) do
+    disk_volume_path = Application.get_env(:game_box, :disk_volume_path)
+
     consume_uploaded_entries(socket, atom, fn %{path: path}, _entry ->
-      dest = Path.join([@disk_volume_path, Path.basename(path)])
+      dest = Path.join([disk_volume_path, Path.basename(path)])
 
       case File.cp(path, dest) do
         :ok -> {:ok, Path.basename(path)}


### PR DESCRIPTION
Deploys are currently failing with the following error. I could go back to using get_env in the consume function but I think it might interfere with how `endpoint.ex` is trying to [serve assets](https://github.com/extism/game_box/blob/main/lib/game_box_web/endpoint.ex#L19)

```
2023-02-14T15:31:56.988 app[79701a76] fra [info] * Compile time value was set to: "priv/static/uploads"
2023-02-14T15:31:56.988 app[79701a76] fra [info] * Runtime value was set to: "/data"
```