### PR TITLE
feat: introduce joined_at logic to players

### DIFF
--- a/lib/game_box/players.ex
+++ b/lib/game_box/players.ex
@@ -12,7 +12,8 @@ defmodule GameBox.Players do
     id: %{type: :string, required: true},
     name: %{type: :string},
     game_id: %{type: :integer},
-    pids: %{type: :array}
+    pids: %{type: :array},
+    joined_at: %{type: :integer, required: true}
   }
 
   @schema Map.new(@fields, fn {key, %{type: type}} -> {key, type} end)
@@ -100,7 +101,8 @@ defmodule GameBox.Players do
 
     cond do
       is_nil(player) and not name_taken ->
-        update.(%{id: player_id, pids: []}, params)
+        joined_at = DateTime.utc_now() |> DateTime.to_unix()
+        update.(%{id: player_id, pids: []}, Map.put(params, :joined_at, joined_at))
 
       name_taken ->
         {:reply, {:error, "Player name already taken"}, state}

--- a/test/game_box/arena/player_test.exs
+++ b/test/game_box/arena/player_test.exs
@@ -21,7 +21,11 @@ defmodule GameBox.Arena.PlayerTest do
               %{
                 id: ^player_id,
                 name: "Test"
-              }} = Players.update_player(arena_id, player_id, %{name: "Test"})
+              }} =
+               Players.update_player(arena_id, player_id, %{
+                 name: "Test",
+                 joined_at: DateTime.utc_now() |> DateTime.to_unix()
+               })
 
       Players.monitor(arena_id, player_id)
       pid = self()

--- a/test/game_box_web/live/arena_live_test.exs
+++ b/test/game_box_web/live/arena_live_test.exs
@@ -32,8 +32,15 @@ defmodule GameBoxWeb.ArenaLiveTest do
 
       :ok = Players.start(arena_id)
 
-      Players.update_player(arena_id, player_one_id, %{name: "Test 1"})
-      Players.update_player(arena_id, player_two_id, %{name: "Test 2"})
+      Players.update_player(arena_id, player_one_id, %{
+        name: "Test 1",
+        joined_at: DateTime.utc_now() |> DateTime.to_unix()
+      })
+
+      Players.update_player(arena_id, player_two_id, %{
+        name: "Test 2",
+        joined_at: DateTime.utc_now() |> DateTime.to_unix()
+      })
 
       {:ok, _view1, html1} = live(conn, ~p"/arena/#{arena_id}")
       {:ok, _view2, html2} = live(conn2, ~p"/arena/#{arena_id}")
@@ -60,8 +67,15 @@ defmodule GameBoxWeb.ArenaLiveTest do
 
       :ok = Players.start(arena_id)
 
-      Players.update_player(arena_id, player_one_id, %{name: "Test 1"})
-      Players.update_player(arena_id, player_two_id, %{name: "Test 2"})
+      Players.update_player(arena_id, player_one_id, %{
+        name: "Test 1",
+        joined_at: DateTime.utc_now() |> DateTime.to_unix()
+      })
+
+      Players.update_player(arena_id, player_two_id, %{
+        name: "Test 2",
+        joined_at: DateTime.utc_now() |> DateTime.to_unix()
+      })
 
       {:ok, view1, html1} = live(conn, ~p"/arena/#{arena_id}")
       {:ok, view2, html2} = live(conn2, ~p"/arena/#{arena_id}")
@@ -114,8 +128,15 @@ defmodule GameBoxWeb.ArenaLiveTest do
 
       :ok = Players.start(arena_id)
 
-      Players.update_player(arena_id, player_one_id, %{name: "Test 1"})
-      Players.update_player(arena_id, player_two_id, %{name: "Test 2"})
+      Players.update_player(arena_id, player_one_id, %{
+        name: "Test 1",
+        joined_at: DateTime.utc_now() |> DateTime.to_unix()
+      })
+
+      Players.update_player(arena_id, player_two_id, %{
+        name: "Test 2",
+        joined_at: DateTime.utc_now() |> DateTime.to_unix()
+      })
 
       {:ok, view1, html1} = live(conn, ~p"/arena/#{arena_id}")
       {:ok, _view2, _html2} = live(conn2, ~p"/arena/#{arena_id}")


### PR DESCRIPTION
connects to #63 
- removes the "too many players to start" guard and introduced `joined_at` timestamps so that we can determine which players to take when starting a game. Any players over the max will be allowed to watch but not participate. 
- moves the game struct into the arena state so that we don't have to look it up quite as many times 
- also adds constraints to the arena state on game selection so that we can reduce the number of times we have to load the plugin to get game information