### PR TITLE
feat: Add forms to Styleguide

### DIFF
--- a/lib/game_box/styleguide.ex
+++ b/lib/game_box/styleguide.ex
@@ -1,0 +1,7 @@
+defmodule GameBox.Styleguide do
+  alias GameBox.Styleguide.ExampleData
+
+  def change_example_data(%ExampleData{} = example_data, attrs \\ %{}) do
+    ExampleData.changeset(example_data, attrs)
+  end
+end

--- a/lib/game_box/styleguide.ex
+++ b/lib/game_box/styleguide.ex
@@ -1,4 +1,7 @@
 defmodule GameBox.Styleguide do
+  @moduledoc """
+  The context for the styleguide form.
+  """
   alias GameBox.Styleguide.ExampleData
 
   def change_example_data(%ExampleData{} = example_data, attrs \\ %{}) do

--- a/lib/game_box/styleguide/exampledata.ex
+++ b/lib/game_box/styleguide/exampledata.ex
@@ -1,8 +1,11 @@
 defmodule GameBox.Styleguide.ExampleData do
+  @moduledoc """
+  The datastructure for the styleguide form.
+  """
+  import Ecto.Changeset
+
   defstruct [:email, :comment, :fruit, :agree]
   @types %{comment: :string, email: :string, fruit: :string, agree: :boolean}
-
-  import Ecto.Changeset
 
   def changeset(%__MODULE__{} = user, attrs) do
     {user, @types}

--- a/lib/game_box/styleguide/exampledata.ex
+++ b/lib/game_box/styleguide/exampledata.ex
@@ -1,0 +1,13 @@
+defmodule GameBox.Styleguide.ExampleData do
+  defstruct [:email, :comment, :fruit, :agree]
+  @types %{comment: :string, email: :string, fruit: :string, agree: :boolean}
+
+  import Ecto.Changeset
+
+  def changeset(%__MODULE__{} = user, attrs) do
+    {user, @types}
+    |> cast(attrs, Map.keys(@types))
+    |> validate_required([:email, :comment, :agree, :fruit])
+    |> validate_format(:email, ~r/@/)
+  end
+end

--- a/lib/game_box_web.ex
+++ b/lib/game_box_web.ex
@@ -56,8 +56,8 @@ defmodule GameBoxWeb do
       # Letimport GameBoxWeb.CoreComponents
       import GameBoxWeb.Code
       import GameBoxWeb.Divider
-      import GameBoxWeb.Typography
       import GameBoxWeb.Tabs
+      import GameBoxWeb.Typography
 
       unquote(view_helpers())
     end

--- a/lib/game_box_web.ex
+++ b/lib/game_box_web.ex
@@ -54,9 +54,10 @@ defmodule GameBoxWeb do
         layout: {GameBoxWeb.LayoutView, :live}
 
       # Letimport GameBoxWeb.CoreComponents
+      import GameBoxWeb.Code
+      import GameBoxWeb.Divider
       import GameBoxWeb.Typography
       import GameBoxWeb.Tabs
-      import GameBoxWeb.Code
 
       unquote(view_helpers())
     end

--- a/lib/game_box_web/components/core_components.ex
+++ b/lib/game_box_web/components/core_components.ex
@@ -294,7 +294,6 @@ defmodule GameBoxWeb.CoreComponents do
   slot :inner_block
 
   def input(%{field: {f, field}} = assigns) do
-    # assigns =
     assigns
     |> assign(field: nil)
     |> assign_new(:name, fn ->

--- a/lib/game_box_web/components/core_components.ex
+++ b/lib/game_box_web/components/core_components.ex
@@ -203,7 +203,7 @@ defmodule GameBoxWeb.CoreComponents do
   def simple_form(assigns) do
     ~H"""
     <.form :let={f} for={@for} as={@as} {@rest}>
-      <div class="space-y-8 mt-10">
+      <div class="space-y-4 mt-10">
         <%= render_slot(@inner_block, f) %>
         <div :for={action <- @actions} class="mt-2 flex items-center justify-between gap-6">
           <%= render_slot(action, f) %>
@@ -294,6 +294,7 @@ defmodule GameBoxWeb.CoreComponents do
   slot :inner_block
 
   def input(%{field: {f, field}} = assigns) do
+    # assigns =
     assigns
     |> assign(field: nil)
     |> assign_new(:name, fn ->
@@ -310,7 +311,7 @@ defmodule GameBoxWeb.CoreComponents do
     assigns = assign_new(assigns, :checked, fn -> input_equals?(assigns.value, "true") end)
 
     ~H"""
-    <label phx-feedback-for={@name} class="flex items-center gap-4 text-sm leading-6 text-white">
+    <label phx-feedback-for={@name} class="flex items-center gap-4 leading-6 text-white">
       <input type="hidden" name={@name} value="false" />
       <input
         type="checkbox"
@@ -323,23 +324,28 @@ defmodule GameBoxWeb.CoreComponents do
       />
       <%= @label %>
     </label>
+    <div phx-feedback-for={@name}>
+      <%= if !@checked do %>
+        <.error :for={msg <- @errors}><%= msg %></.error>
+      <% end %>
+    </div>
     """
   end
 
   def input(%{type: "select"} = assigns) do
     ~H"""
+    <.label for={@id}><%= @label %></.label>
+    <select
+      id={@id}
+      name={@name}
+      class="mt-1 block w-full py-2 px-3 bg-dark rounded-md shadow-sm focus:outline-none focus:ring-primary focus:border-primary-dark sm:text-sm phx-no-feedback:border-zinc-700 phx-no-feedback:focus:border-zinc-500 phx-no-feedback:focus:ring-zinc-800/5"
+      multiple={@multiple}
+      {@rest}
+    >
+      <option :if={@prompt} value=""><%= @prompt %></option>
+      <%= Form.options_for_select(@options, @value) %>
+    </select>
     <div phx-feedback-for={@name}>
-      <.label for={@id}><%= @label %></.label>
-      <select
-        id={@id}
-        name={@name}
-        class="mt-1 block w-full py-2 px-3 border border-gray-300 bg-white rounded-md shadow-sm focus:outline-none focus:ring-primary focus:border-primary-dark sm:text-sm"
-        multiple={@multiple}
-        {@rest}
-      >
-        <option :if={@prompt} value=""><%= @prompt %></option>
-        <%= Form.options_for_select(@options, @value) %>
-      </select>
       <.error :for={msg <- @errors}><%= msg %></.error>
     </div>
     """
@@ -354,9 +360,9 @@ defmodule GameBoxWeb.CoreComponents do
         name={@name}
         class={[
           input_border(@errors),
-          "mt-2 block min-h-[6rem] w-full rounded-lg border-zinc-800 py-[7px] px-[11px]",
-          "text-zinc-900 focus:border-zinc-400 focus:outline-none focus:ring-4 focus:ring-zinc-800/5 sm:text-sm sm:leading-6",
-          "phx-no-feedback:border-zinc-300 phx-no-feedback:focus:border-zinc-400 phx-no-feedback:focus:ring-zinc-800/5"
+          "mt-2 block min-h-[6rem] w-full rounded-lg border-zinc-800 py-[7px] px-[11px] bg-dark",
+          "text-white focus:border-primary-dark focus:ring-4 sm:text-sm sm:leading-6",
+          "phx-no-feedback:border-zinc-700 phx-no-feedback:focus:border-primary-dark phx-no-feedback:focus:ring-zinc-800/5"
         ]}
         {@rest}
       >
@@ -379,7 +385,7 @@ defmodule GameBoxWeb.CoreComponents do
           input_border(@errors),
           "mt-2 block w-full rounded-lg py-[7px] px-[11px] bg-dark",
           "text-white focus:outline-none focus:ring-4 sm:text-sm sm:leading-6",
-          "phx-no-feedback:border-zinc-700 phx-no-feedback:focus:border-zinc-500 phx-no-feedback:focus:ring-zinc-800/5"
+          "phx-no-feedback:border-zinc-700 phx-no-feedback:focus:border-primary-dark  phx-no-feedback:focus:ring-zinc-800/5"
         ]}
         {@rest}
       />
@@ -392,8 +398,9 @@ defmodule GameBoxWeb.CoreComponents do
     do: ""
 
   defp input_border([_ | _] = _errors),
-    do: ""
+    do: "border-error focus:border-errorfocus:ring-error/10"
 
+  @spec label(map) :: Phoenix.LiveView.Rendered.t()
   @doc """
   Renders a label.
   """
@@ -415,8 +422,7 @@ defmodule GameBoxWeb.CoreComponents do
 
   def error(assigns) do
     ~H"""
-    <p class="phx-no-feedback:hidden mt-3 flex gap-3 text-sm leading-6 text-rose-600">
-      <!--<Heroicons.exclamation_circle mini class="mt-0.5 h-5 w-5 flex-none fill-rose-500" />-->
+    <p class="phx-no-feedback:hidden mt-3 flex gap-3 text-sm leading-6 text-error">
       <%= render_slot(@inner_block) %>
     </p>
     """

--- a/lib/game_box_web/components/divider.ex
+++ b/lib/game_box_web/components/divider.ex
@@ -1,4 +1,8 @@
 defmodule GameBoxWeb.Divider do
+  @moduledoc """
+  Light gray divider used for breaking up content.
+  """
+
   use Phoenix.Component
 
   def mount(_params, _session, socket) do

--- a/lib/game_box_web/components/divider.ex
+++ b/lib/game_box_web/components/divider.ex
@@ -1,0 +1,13 @@
+defmodule GameBoxWeb.Divider do
+  use Phoenix.Component
+
+  def mount(_params, _session, socket) do
+    {:ok, socket}
+  end
+
+  def divider(assigns) do
+    ~H"""
+    <div class="border-b border-1 border-zinc-600 mb-5"></div>
+    """
+  end
+end

--- a/lib/game_box_web/components/typography.ex
+++ b/lib/game_box_web/components/typography.ex
@@ -114,7 +114,7 @@ defmodule GameBoxWeb.Typography do
 
   def p(assigns) do
     ~H"""
-    <p class={build_class([text_base_class(), "mb-2 text-secondary", @class])} {@rest}>
+    <p class={build_class([text_base_class(), "my-4 text-secondary", @class])} {@rest}>
       <%= render_slot(@inner_block) %>
     </p>
     """

--- a/lib/game_box_web/live/styleguide/colors.html.heex
+++ b/lib/game_box_web/live/styleguide/colors.html.heex
@@ -1,19 +1,22 @@
 <div class="flex flex-col gap-y-12">
   <div>
     <.h2>Colors</.h2>
-    <.p>
-      Custom colors can be used in conjunction with any other TailwindCSS prefix that utilizes color.
-    </.p>
+    <div class="max-w-2xl">
+      <.p>
+        Custom colors can be used in conjunction with any other TailwindCSS prefix that utilizes color.
+      </.p>
+    </div>
     <% code = """
     <div class="bg-primary"></div> 
     <span class="text-primary"></span>
     <div class="border border-primary"></div> 
     """ %>
     <.code content={code} />
-
-    <.p class="mt-10">
-      The nested keys can be combined with the parent key to form class names like bg-primary-dark.
-    </.p>
+    <div class="max-w-2xl">
+      <.p class="mt-10">
+        The nested keys can be combined with the parent key to form class names like bg-primary-dark.
+      </.p>
+    </div>
     <% code = """
     <div class="bg-primary-light"></div> 
     <span class="text-primary-dark"></span>

--- a/lib/game_box_web/live/styleguide/form_fields.html.heex
+++ b/lib/game_box_web/live/styleguide/form_fields.html.heex
@@ -1,0 +1,1 @@
+<.h2>Forms + Form Fields</.h2> 

--- a/lib/game_box_web/live/styleguide/form_fields.html.heex
+++ b/lib/game_box_web/live/styleguide/form_fields.html.heex
@@ -1,1 +1,48 @@
 <.h2>Forms + Form Fields</.h2> 
+
+<.h2>Form</.h2> 
+<.p>To create a working form, you must wrap the input fields below in a &lt;.simple_form> tag. You must also include the submit button within an &lt;:actions> named slot. A complete form might look like the following:</.p>
+<%
+code = 
+"""
+<.simple_form :let={f} for={:user} phx-change="validate" phx-submit="save">
+    <.input field={{f, :email}} label="Email"/>
+    <.input field={{f, :username}} label="Username" />
+    <:actions>
+      <.button>Save</.button>
+    </:actions>
+  </.simple_form>
+"""
+%> 
+
+<.h5 label="Code Example:" />
+<.code content={code} />
+
+<% 
+ attr = """
+ attr :for, :any, default: nil, doc: "the datastructure for the form"
+ attr :as, :any, default: nil, doc: "the server side parameter to collect all input under"
+
+ attr :rest, :global,
+   include: ~w(autocomplete name rel action enctype method novalidate target),
+   doc: "the arbitrary HTML attributes to apply to the form tag"
+
+ slot :inner_block, required: true
+ slot :actions, doc: "the slot for form actions, such as a submit button"
+ """
+%> 
+
+<.h5 label="Attributes/Slots:" />
+<.code content={attr} />
+
+
+
+
+<div class="max-w-2xl">
+    <.simple_form :let={f} for={:fakeform}>
+        <.input field={{f, :text_input}} label="Text Input"/>
+    
+    </.simple_form> 
+    </div>
+
+

--- a/lib/game_box_web/live/styleguide/form_fields.html.heex
+++ b/lib/game_box_web/live/styleguide/form_fields.html.heex
@@ -1,48 +1,179 @@
-<.h2>Forms + Form Fields</.h2> 
+<div class="flex flex-col gap-y-12">
+  <div class="max-w-2xl">
+    <.h2>Forms + Form Fields</.h2>
 
-<.h2>Form</.h2> 
-<.p>To create a working form, you must wrap the input fields below in a &lt;.simple_form> tag. You must also include the submit button within an &lt;:actions> named slot. A complete form might look like the following:</.p>
-<%
-code = 
-"""
-<.simple_form :let={f} for={:user} phx-change="validate" phx-submit="save">
-    <.input field={{f, :email}} label="Email"/>
-    <.input field={{f, :username}} label="Username" />
-    <:actions>
-      <.button>Save</.button>
-    </:actions>
-  </.simple_form>
-"""
-%> 
+    <.p>
+      These functions all based on Phoenix's Core Components and are located in the core_components.ex file.
+    </.p>
+  </div>
+  <.divider />
+  <div>
+    <.h3>Example Form</.h3>
+    <.p>
+      Validation is triggered on field blur or by clicking the "Test Submit" button. No data will be saved/submitted.
+    </.p>
 
-<.h5 label="Code Example:" />
-<.code content={code} />
-
-<% 
- attr = """
- attr :for, :any, default: nil, doc: "the datastructure for the form"
- attr :as, :any, default: nil, doc: "the server side parameter to collect all input under"
-
- attr :rest, :global,
-   include: ~w(autocomplete name rel action enctype method novalidate target),
-   doc: "the arbitrary HTML attributes to apply to the form tag"
-
- slot :inner_block, required: true
- slot :actions, doc: "the slot for form actions, such as a submit button"
- """
-%> 
-
-<.h5 label="Attributes/Slots:" />
-<.code content={attr} />
-
-
-
-
-<div class="max-w-2xl">
-    <.simple_form :let={f} for={:fakeform}>
-        <.input field={{f, :text_input}} label="Text Input"/>
-    
-    </.simple_form> 
+    <.simple_form
+      :let={f}
+      for={@changeset}
+      method="put"
+      phx-change="validate"
+      phx-submit="validate"
+    >
+      <.input field={{f, :email}} type="email" label="Email Text Input" phx-debounce="blur" />
+      <.input field={{f, :comment}} type="textarea" label="Comment Text Area" />
+      <.input
+        field={{f, :fruit}}
+        type="select"
+        label="Fruit Select"
+        options={["", "Apple", "Banana", "Orange"]}
+      />
+      <.input
+        field={{f, :agree}}
+        type="checkbox"
+        label="Checkbox Agreement"
+        errors={["required"]}
+      />
+      <:actions>
+        <.button>Test Submit</.button>
+      </:actions>
+    </.simple_form>
+  </div>
+  <.divider />
+  <div>
+    <.h2>Simple Form</.h2>
+    <div class="max-w-2xl">
+      <.p>
+        To create a working form, you must wrap the &lt;.input> fields in a &lt;.simple_form> tag.
+        You must also include the submit button within an &lt;:actions> named slot. A complete form
+        might look like the following:
+      </.p>
     </div>
+  </div>
+  <div>
+    <% code = """
+    <.simple_form :let={f} for={:user} phx-change="validate" phx-submit="save">
+        <.input field={{f, :email}} label="Email"/>
+        <.input field={{f, :username}} label="Username" />
+        <:actions>
+          <.button>Save</.button>
+        </:actions>
+    </.simple_form>
+    """ %>
+    <.h5 label="Code Example:" />
+    <.code content={code} />
+  </div>
+  <div class="mb-12">
+    <% attr = """
+    attr :for, :any, default: nil, doc: "the datastructure for the form"
+    attr :as, :any, default: nil, doc: "the server side parameter to collect all input under"
 
+    attr :rest, :global,
+      include: ~w(autocomplete name rel action enctype method novalidate target),
+      doc: "the arbitrary HTML attributes to apply to the form tag"
 
+    slot :inner_block, required: true
+    slot :actions, doc: "the slot for form actions, such as a submit button"
+    """ %>
+
+    <.h5 label="Attributes/Slots:" />
+    <.code content={attr} />
+  </div>
+</div>
+
+<.divider />
+<div class="flex flex-col mt-12 gap-y-12">
+  <div class="max-w-2xl">
+    <.h2>Input</.h2>
+
+    <.p>Renders an input with label and error messages.</.p>
+
+    <.p>A `%Phoenix.HTML.Form{}` and field name may be passed to the input
+      to build input names and error messages, or all the attributes and
+      errors may be passed explicitly.</.p>
+  </div>
+  <div>
+    <% attr = """
+    attr :id, :any
+    attr :name, :any
+    attr :label, :string, default: nil
+
+    attr :type, :string,
+    default: "text",
+    values: ~w(checkbox color date datetime-local email file hidden month number password
+                range radio search select tel text textarea time url week)
+
+    attr :value, :any
+    attr :field, :any, doc: "a %Phoenix.HTML.Form{}/field name tuple, for example: {f, :email}"
+    attr :errors, :list
+    attr :checked, :boolean, doc: "the checked flag for checkbox inputs"
+    attr :prompt, :string, default: nil, doc: "the prompt for select inputs"
+    attr :options, :list, doc: "the options to pass to Phoenix.HTML.Form.options_for_select/2"
+    attr :multiple, :boolean, default: false, doc: "the multiple flag for select inputs"
+    attr :rest, :global, include: ~w(autocomplete cols disabled form max maxlength min minlength
+                                    pattern placeholder readonly required rows size step)
+    slot :inner_block
+    """ %>
+
+    <.h5 label="Attributes/Slots:" />
+    <.code content={attr} />
+  </div>
+  <div>
+    <div class="max-w-2xl mb-6">
+      <.h3>Text Input</.h3>
+
+      <.p>Single line text input control. This is the default input type.</.p>
+    </div>
+    <div>
+      <% code = """
+      <.input field={{f, :email}} type="email" />
+      <.input name="my-input" errors={["required"]} />
+      """ %>
+
+      <.h5 label="Code Example:" />
+      <.code content={code} />
+    </div>
+  </div>
+  <div>
+    <div class="max-w-2xl mb-6">
+      <.h2>Textarea</.h2>
+      <.p>Multi-line text input control.</.p>
+    </div>
+    <div>
+      <% code = """
+      <.input field={{f, :comments}} type="textarea" label="Comments" />
+      """ %>
+
+      <.h5 label="Code Example:" />
+      <.code content={code} />
+    </div>
+  </div>
+  <div>
+    <div class="max-w-2xl mb-6">
+      <.h2>Select</.h2>
+      <.p>Used to create a drop-down list.</.p>
+    </div>
+    <div>
+      <% code = """
+      <.input field={{f, :fruit}} type="select" label="Fruit" options={["","Apple", "Banana", "Orange"]} />
+      """ %>
+
+      <.h5 label="Code Example:" />
+      <.code content={code} />
+    </div>
+  </div>
+  <div>
+    <div class="max-w-2xl mb-6">
+      <.h2>Checkbox</.h2>
+      <.p>Allow users to select one or more of a limited number of options.</.p>
+    </div>
+    <div>
+      <% code = """
+      <.input field={{f, :agree}} type="checkbox" label="I agree" />
+      """ %>
+
+      <.h5 label="Code Example:" />
+      <.code content={code} />
+    </div>
+  </div>
+</div>

--- a/lib/game_box_web/live/styleguide/typography.html.heex
+++ b/lib/game_box_web/live/styleguide/typography.html.heex
@@ -34,7 +34,7 @@
     <.code content={code} />
   </div>
 
-  <div class="border-b border-1 border-zinc-600 mb-5"></div>
+  <.divider />
   <div>
     <.h2>Paragraphs</.h2>
     <.p>The quick brown fox jumps over the lazy dog.</.p>
@@ -56,7 +56,7 @@
     <.h5 label="Code Example" />
     <.code content={code} />
   </div>
-  <div class="border-b border-1 border-zinc-600 mb-5"></div>
+  <.divider />
   <div>
     <.h2>Ordered Lists</.h2>
     <.ol>
@@ -85,7 +85,7 @@
     <.h5 label="Code Example" />
     <.code content={code} />
   </div>
-  <div class="border-b border-1 border-zinc-600 mb-5"></div>
+  <.divider />
   <div>
     <.h2>Unordered Lists</.h2>
     <.ul>

--- a/lib/game_box_web/live/styleguide_live.ex
+++ b/lib/game_box_web/live/styleguide_live.ex
@@ -54,7 +54,6 @@ defmodule GameBoxWeb.StyleguideLive do
     """
   end
 
-  @spec handle_params(any, any, any) :: {:noreply, any}
   def handle_params(_params, _url, socket) do
     {:noreply, socket}
   end

--- a/lib/game_box_web/live/styleguide_live.ex
+++ b/lib/game_box_web/live/styleguide_live.ex
@@ -54,13 +54,14 @@ defmodule GameBoxWeb.StyleguideLive do
     """
   end
 
-  def handle_params(params, _url, socket) do
+  @spec handle_params(any, any, any) :: {:noreply, any}
+  def handle_params(_params, _url, socket) do
     {:noreply, socket}
   end
 
   def handle_event(
         "validate",
-        %{"example_data" => example_data_params} = params,
+        %{"example_data" => example_data_params},
         %{assigns: %{example_data: example_data}} = socket
       ) do
     changeset =

--- a/lib/game_box_web/live/styleguide_live.ex
+++ b/lib/game_box_web/live/styleguide_live.ex
@@ -27,10 +27,10 @@ defmodule GameBoxWeb.StyleguideLive do
         is_active={is_active?(@live_action, :typography)}
       />
       <.tab
-        patch={Routes.styleguide_path(@socket, :buttons)}
+        patch={Routes.styleguide_path(@socket, :form_fields)}
         replace={true}
-        label="Buttons"
-        is_active={is_active?(@live_action, :buttons)}
+        label="Form"
+        is_active={is_active?(@live_action, :form_fields)}
       />
     </.tabs>
     <div class="mx-3">
@@ -41,6 +41,8 @@ defmodule GameBoxWeb.StyleguideLive do
           <.typography />
         <% :buttons -> %>
           <.buttons />
+        <% :form_fields -> %>
+          <.form_fields />
       <% end %>
     </div>
     """

--- a/lib/game_box_web/live/styleguide_live.ex
+++ b/lib/game_box_web/live/styleguide_live.ex
@@ -1,14 +1,20 @@
 defmodule GameBoxWeb.StyleguideLive do
   use GameBoxWeb, :live_view
-  # import Phoenix.Component, only: [embed_templates: 1]
   import GameBoxWeb.ColorSwatch
+
+  alias GameBox.Styleguide
+  alias GameBox.Styleguide.ExampleData
 
   embed_templates "styleguide/*"
 
-  # def mount(_params, _session, socket) do
-  #   socket = assign(socket, is_active: false)
-  #   {:ok, socket}
-  # end
+  def mount(_params, _session, socket) do
+    socket =
+      socket
+      |> assign(:example_data, %ExampleData{})
+      |> assign(:changeset, Styleguide.change_example_data(%ExampleData{}))
+
+    {:ok, socket}
+  end
 
   def render(assigns) do
     ~H"""
@@ -42,14 +48,27 @@ defmodule GameBoxWeb.StyleguideLive do
         <% :buttons -> %>
           <.buttons />
         <% :form_fields -> %>
-          <.form_fields />
+          <.form_fields changeset={@changeset} />
       <% end %>
     </div>
     """
   end
 
-  def handle_params(_params, _url, socket) do
+  def handle_params(params, _url, socket) do
     {:noreply, socket}
+  end
+
+  def handle_event(
+        "validate",
+        %{"example_data" => example_data_params} = params,
+        %{assigns: %{example_data: example_data}} = socket
+      ) do
+    changeset =
+      example_data
+      |> Styleguide.change_example_data(example_data_params)
+      |> Map.put(:action, :validate)
+
+    {:noreply, assign(socket, :changeset, changeset)}
   end
 
   defp is_active?(live_action, current) do

--- a/lib/game_box_web/router.ex
+++ b/lib/game_box_web/router.ex
@@ -35,6 +35,7 @@ defmodule GameBoxWeb.Router do
     live "/styleguide/typography", StyleguideLive, :typography
     live "/styleguide/colors", StyleguideLive, :colors
     live "/styleguide/buttons", StyleguideLive, :buttons
+    live "/styleguide/form", StyleguideLive, :form_fields
 
     live_session(:default, on_mount: GameBoxWeb.InitAssigns) do
       live("/home", HomeLive)


### PR DESCRIPTION
_connects to #25_ 

The purpose of this PR is to add forms to the styleguide. It demonstrates how to use the form components, describes where they should be used, and displays an example form that validates on change or submit. 

![Screenshot 2023-02-17 at 06-19-01 Game Box](https://user-images.githubusercontent.com/65098991/219654861-0d04f150-a474-413f-aeb2-b13d35c7350c.png)

<img width="1698" alt="Screenshot 2023-02-17 at 6 34 12 AM" src="https://user-images.githubusercontent.com/65098991/219655025-703d1ef2-2a07-4851-9a94-f895f8f2d7ab.png">
