### PR TITLE
fix: Manually free plugin on unset call

### DIFF
--- a/lib/game_box/arena.ex
+++ b/lib/game_box/arena.ex
@@ -198,7 +198,11 @@ defmodule GameBox.Arena do
 
   @impl true
   def handle_call({:unset_game, _game_id}, _from, state) do
-    %{arena_id: arena_id} = state
+    %{plugin: plugin, arena_id: arena_id} = state
+
+    unless is_nil(plugin) do
+      Extism.Plugin.free(plugin)
+    end
 
     state =
       state


### PR DESCRIPTION
When you have a long running context, like we do here, plugins must be freed manually. The plugin was eventually getting freed but only when the context was GCd.