### PR TITLE
fix: Another potential memory leak in the arena

### DIFF
--- a/lib/game_box/arena.ex
+++ b/lib/game_box/arena.ex
@@ -136,7 +136,7 @@ defmodule GameBox.Arena do
 
   def handle_call({:extism, "get_constraints"}, _from, %{plugin: plugin, game: game} = arena) do
     # If the plugin is nil, we should load up a temporary plugin
-    # TODO we could perhaps remove the semantic association that
+    # we could perhaps remove the semantic association that
     # !is_nil(plugin) means that a game is started in the "render" callback
     constraints = if is_nil(plugin) do
       disk_volume_path = Application.get_env(:game_box, :disk_volume_path)


### PR DESCRIPTION
I haven't tested, but it appears that we may not be properly freeing this plugin in get_constraints. This handles if both a plugin exists or doesn't exist. I think it's a mistake to assume, as we do in the render callback, that if a plugin is non-nil then the game is started. we should maybe have some other piece of state tell us that. Then we can just lazily load the plugin and keep it around until we switch the game out.