### PR TITLE
fix: upcasae arena and player on submit

### DIFF
--- a/lib/game_box_web/live/arena_live.ex
+++ b/lib/game_box_web/live/arena_live.ex
@@ -33,7 +33,7 @@ defmodule GameBoxWeb.ArenaLive do
 
         true ->
           socket
-          |> put_flash(:error, "Looks like that arena does not exist!")
+          |> put_flash(:error, "Looks like that arena does not exist or you have not joined it!")
           |> push_navigate(to: Routes.live_path(GameBoxWeb.Endpoint, GameBoxWeb.HomeLive))
       end
 

--- a/lib/game_box_web/live/home_live.ex
+++ b/lib/game_box_web/live/home_live.ex
@@ -76,6 +76,9 @@ defmodule GameBoxWeb.HomeLive do
       ) do
     %{assigns: %{player_id: player_id}} = socket
 
+    arena_id = String.upcase(arena_id)
+    player_name = String.upcase(player_name)
+
     case Arena.start(arena_id) do
       {:ok, :initiated} ->
         Arena.set_host(arena_id, player_id)
@@ -112,7 +115,7 @@ defmodule GameBoxWeb.HomeLive do
     {:noreply, assign(socket, games: games)}
   end
 
-  def validate_arena(attrs, changeset) do
+  defp validate_arena(attrs, changeset) do
     {changeset, @arena_types}
     |> Changeset.cast(attrs, Map.keys(@arena_types))
     |> Changeset.validate_required([:player_name, :arena_id])

--- a/test/game_box_web/live/home_live_test.exs
+++ b/test/game_box_web/live/home_live_test.exs
@@ -9,11 +9,11 @@ defmodule GameBoxWeb.HomeLiveTest do
 
       view
       |> element("#join_arena")
-      |> render_submit(%{arena_form: %{player_name: "Joe", arena_id: "ABCD"}})
+      |> render_submit(%{arena_form: %{player_name: "Joe", arena_id: "abcd"}})
 
       path = ~p"/arena/ABCD"
       assert {^path, %{}} = assert_redirect(view)
-      assert %{id: ^player_id, name: "Joe"} = GameBox.Players.get_player("ABCD", player_id)
+      assert %{id: ^player_id, name: "JOE"} = GameBox.Players.get_player("ABCD", player_id)
       assert %{arena_id: "ABCD"} = GameBox.Arena.state("ABCD")
     end
   end


### PR DESCRIPTION
connects to #74

This upcases the `player_name` and `arena_id` after the join arena form is submitted but before using the values to create/join. 