### PR TITLE
refactor: Convert Route helpers into verified routes

### DIFF
--- a/lib/game_box_web/controllers/auth_controller.ex
+++ b/lib/game_box_web/controllers/auth_controller.ex
@@ -13,7 +13,7 @@ defmodule GameBoxWeb.AuthController do
     conn
     |> put_flash(:info, "You have been logged out!")
     |> clear_session()
-    |> redirect(to: Routes.live_path(GameBoxWeb.Endpoint, GameBoxWeb.HomeLive))
+    |> redirect(to: ~p"/")
   end
 
   def callback(%{assigns: %{ueberauth_failure: _fails}} = conn, _params) do
@@ -36,12 +36,12 @@ defmodule GameBoxWeb.AuthController do
     |> put_flash(:info, "Successfully authenticated #{user.gh_login}")
     |> put_session(:user_id, user.id)
     |> configure_session(renew: true)
-    |> redirect(to: Routes.live_path(GameBoxWeb.Endpoint, GameBoxWeb.HomeLive))
+    |> redirect(to: ~p"/")
   end
 
   defp handle_failure(conn) do
     conn
     |> put_flash(:error, "Failed to authenticate.")
-    |> redirect(to: Routes.live_path(GameBoxWeb.Endpoint, GameBoxWeb.HomeLive))
+    |> redirect(to: ~p"/")
   end
 end

--- a/lib/game_box_web/live/arena_live.ex
+++ b/lib/game_box_web/live/arena_live.ex
@@ -34,7 +34,7 @@ defmodule GameBoxWeb.ArenaLive do
         true ->
           socket
           |> put_flash(:error, "Looks like that arena does not exist or you have not joined it!")
-          |> push_navigate(to: Routes.live_path(GameBoxWeb.Endpoint, GameBoxWeb.HomeLive))
+          |> push_navigate(to: ~p"/")
       end
 
     {:ok, socket}

--- a/lib/game_box_web/live/styleguide_live.ex
+++ b/lib/game_box_web/live/styleguide_live.ex
@@ -21,25 +21,25 @@ defmodule GameBoxWeb.StyleguideLive do
     <.hero header="Styleguide" />
     <.tabs class="my-10">
       <.tab
-        patch={Routes.styleguide_path(@socket, :styleguide)}
+        patch={~p"/styleguide"}
         replace={true}
         label="Colors"
         is_active={is_active?(@live_action, :styleguide)}
       />
       <.tab
-        patch={Routes.styleguide_path(@socket, :typography)}
+        patch={~p"/styleguide/typography"}
         replace={true}
         label="Typography"
         is_active={is_active?(@live_action, :typography)}
       />
       <.tab
-        patch={Routes.styleguide_path(@socket, :form_fields)}
+        patch={~p"/styleguide/form"}
         replace={true}
         label="Form"
         is_active={is_active?(@live_action, :form_fields)}
       />
       <.tab
-        patch={Routes.styleguide_path(@socket, :containers)}
+        patch={~p"/styleguide/containers"}
         replace={true}
         label="Content Containers"
         is_active={is_active?(@live_action, :containers)}

--- a/lib/game_box_web/live/upload_live.ex
+++ b/lib/game_box_web/live/upload_live.ex
@@ -194,7 +194,7 @@ defmodule GameBoxWeb.UploadLive do
 
           socket
           |> put_flash(:info, "Game successfully uploaded!")
-          |> redirect(to: Routes.live_path(socket, GameBoxWeb.UploadLive))
+          |> redirect(to: ~p"/upload")
 
         {:error, %Ecto.Changeset{} = changeset} ->
           socket


### PR DESCRIPTION
The purpose of this PR is to convert route helpers into verified routes. This ensures that we'll receive compile-time warnings if any paths are incorrect, and it makes our links and redirects considerably less verbose. 