### PR TITLE
refactor: Arena Styling

### DIFF
--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -38,8 +38,14 @@ window.addEventListener("phx:page-loading-stop", info => topbar.hide())
 // Allow a user to copy the arena code 
 window.addEventListener("gamebox:clipcopy", (event) => {
     if ("clipboard" in navigator) {
-      const text = event.target.textContent;
+      const text = event.target.value;
       navigator.clipboard.writeText(text);
+
+      var copied_text = document.getElementsByClassName("copied");
+      for (let i = 0; i < copied_text.length; i++) {
+        copied_text[i].classList.remove("hidden")
+      }
+
     } else {
       alert("Sorry, your browser does not support clipboard copy.");
     }

--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -35,6 +35,16 @@ topbar.config({barColors: {0: "#29d"}, shadowColor: "rgba(0, 0, 0, .3)"})
 window.addEventListener("phx:page-loading-start", info => topbar.show())
 window.addEventListener("phx:page-loading-stop", info => topbar.hide())
 
+// Allow a user to copy the arena code 
+window.addEventListener("gamebox:clipcopy", (event) => {
+    if ("clipboard" in navigator) {
+      const text = event.target.textContent;
+      navigator.clipboard.writeText(text);
+    } else {
+      alert("Sorry, your browser does not support clipboard copy.");
+    }
+  });
+
 // connect if there are any LiveViews on the page
 liveSocket.connect()
 

--- a/lib/game_box_web.ex
+++ b/lib/game_box_web.ex
@@ -53,6 +53,7 @@ defmodule GameBoxWeb do
       use Phoenix.LiveView,
         layout: {GameBoxWeb.LayoutView, :live}
 
+      import GameBoxWeb.ArenaCode
       import GameBoxWeb.Card
       import GameBoxWeb.Container
       import GameBoxWeb.Code

--- a/lib/game_box_web/components/arena_code.ex
+++ b/lib/game_box_web/components/arena_code.ex
@@ -1,0 +1,32 @@
+defmodule GameBoxWeb.ArenaCode do
+  use Phoenix.Component
+
+  import GameBoxWeb.Typography
+  alias Phoenix.LiveView.JS
+
+  def arena_code(assigns) do
+    ~H"""
+    <.h5 class="!text-primary !pt-0 !mt-0" label="Arena" />
+    <.h1 :if={@arena_id} label={@arena_id} />
+
+    <.p class="text-sm">
+      Have your friends enter this code at gamebox.fly.dev to join!
+    </.p>
+
+    <div>
+      <.p class="text-secondary text-sm !m-0">
+        Or
+        <a
+          class="cursor-pointer underline text-primary hover:text-white"
+          phx-click={JS.dispatch("gamebox:clipcopy", to: "#arena-code")}
+        >
+          copy an invite link
+        </a>
+        <div class="copied hidden text-xs italic">Copied!</div>
+      </.p>
+
+      <input type="hidden" id="arena-code" value={"gamebox.fly.dev/join?arena=#{@arena_id}"} />
+    </div>
+    """
+  end
+end

--- a/lib/game_box_web/components/arena_code.ex
+++ b/lib/game_box_web/components/arena_code.ex
@@ -5,6 +5,7 @@ defmodule GameBoxWeb.ArenaCode do
   use Phoenix.Component
 
   import GameBoxWeb.Typography
+  alias GameBoxWeb.Router.Helpers, as: Routes
   alias Phoenix.LiveView.JS
 
   def arena_code(assigns) do
@@ -13,7 +14,7 @@ defmodule GameBoxWeb.ArenaCode do
     <.h1 :if={@arena_id} label={@arena_id} />
 
     <.p class="text-sm">
-      Have your friends enter this code at gamebox.fly.dev to join!
+      Have your friends enter this code at <%= @uri %> to join!
     </.p>
 
     <div>
@@ -28,7 +29,7 @@ defmodule GameBoxWeb.ArenaCode do
         <div class="copied hidden text-xs italic">Copied!</div>
       </.p>
 
-      <input type="hidden" id="arena-code" value={"gamebox.fly.dev/join?arena=#{@arena_id}"} />
+      <input type="hidden" id="arena-code" value={"#{@uri}/join?arena=#{@arena_id}"} />
     </div>
     """
   end

--- a/lib/game_box_web/components/arena_code.ex
+++ b/lib/game_box_web/components/arena_code.ex
@@ -1,4 +1,7 @@
 defmodule GameBoxWeb.ArenaCode do
+  @moduledoc """
+  A component for displaying the Arena Code and a copy link.
+  """
   use Phoenix.Component
 
   import GameBoxWeb.Typography

--- a/lib/game_box_web/components/arena_code.ex
+++ b/lib/game_box_web/components/arena_code.ex
@@ -17,18 +17,32 @@ defmodule GameBoxWeb.ArenaCode do
     </.p>
 
     <div>
-      <.p class="text-secondary text-sm !m-0">
-        Or
-        <a
-          class="cursor-pointer underline text-primary hover:text-white"
-          phx-click={JS.dispatch("gamebox:clipcopy", to: "#arena-code")}
-        >
-          copy an invite link
-        </a>
-        <div class="copied hidden text-xs italic">Copied!</div>
-      </.p>
+      <div class="w-5/6">
+        <label for="email" class="block text-sm text-secondary">Copy invite link:</label>
+        <div class="mt-1 flex rounded-md shadow-sm">
+          <div class="relative flex flex-grow items-stretch focus-within:z-10">
+            <input
+              id="arena-code"
+              class={[
+                "block w-full rounded-lg py-[7px] px-[11px] bg-dark border border-zinc-800",
+                "text-white focus:outline-none focus:ring-4 sm:text-xs sm:leading-6",
+                "border-zinc-700 focus:border-primary-dark focus:ring-zinc-800/5"
+              ]}
+              value={"#{@uri}/join?arena=#{@arena_id}"}
+            />
+          </div>
 
-      <input type="hidden" id="arena-code" value={"#{@uri}/join?arena=#{@arena_id}"} />
+          <button
+            phx-click={JS.dispatch("gamebox:clipcopy", to: "#arena-code")}
+            type="button"
+            class="relative -ml-px inline-flex items-center rounded-r-md border border-zinc-800 bg-dark px-2 py-1 text-sm font-medium text-primary hover:bg-primary hover:text-white focus:border-primary focus:outline-none focus:ring-1 focus:ring-primary"
+          >
+            <span>Copy</span>
+          </button>
+        </div>
+      </div>
+
+      <div class="copied hidden text-xs italic">Copied!</div>
     </div>
     """
   end

--- a/lib/game_box_web/components/arena_code.ex
+++ b/lib/game_box_web/components/arena_code.ex
@@ -5,7 +5,6 @@ defmodule GameBoxWeb.ArenaCode do
   use Phoenix.Component
 
   import GameBoxWeb.Typography
-  alias GameBoxWeb.Router.Helpers, as: Routes
   alias Phoenix.LiveView.JS
 
   def arena_code(assigns) do

--- a/lib/game_box_web/components/arena_code.ex
+++ b/lib/game_box_web/components/arena_code.ex
@@ -18,7 +18,7 @@ defmodule GameBoxWeb.ArenaCode do
 
     <div>
       <div class="w-5/6">
-        <label for="email" class="block text-sm text-secondary">Copy invite link:</label>
+        <label for="email" class="block text-sm text-secondary">Or copy invite link:</label>
         <div class="mt-1 flex rounded-md shadow-sm">
           <div class="relative flex flex-grow items-stretch focus-within:z-10">
             <input

--- a/lib/game_box_web/components/core_components.ex
+++ b/lib/game_box_web/components/core_components.ex
@@ -261,6 +261,22 @@ defmodule GameBoxWeb.CoreComponents do
     """
   end
 
+  def button(%{color: "primary", variant: "tiny"} = assigns) do
+    ~H"""
+    <button
+      type={@type}
+      class={[
+        "phx-submit-loading:opacity-75 block rounded-lg bg-dark border border-primary hover:bg-primary p-2",
+        "font-display tracking-wider text-xs text-primary hover:text-white ",
+        @class
+      ]}
+      {@rest}
+    >
+      <%= render_slot(@inner_block) || @label %>
+    </button>
+    """
+  end
+
   @doc """
   Renders an input with label and error messages.
 

--- a/lib/game_box_web/components/core_components.ex
+++ b/lib/game_box_web/components/core_components.ex
@@ -234,7 +234,7 @@ defmodule GameBoxWeb.CoreComponents do
     <button
       type={@type}
       class={[
-        "phx-submit-loading:opacity-75 block rounded-lg bg-primary hover:bg-primary-dark py-4 px-4 mt-3",
+        "phx-submit-loading:opacity-75 block rounded-lg bg-primary hover:bg-primary-dark py-4 px-4",
         "font-display tracking-wider text-xs text-dark hover:text-white ",
         @class
       ]}
@@ -250,7 +250,7 @@ defmodule GameBoxWeb.CoreComponents do
     <button
       type={@type}
       class={[
-        "phx-submit-loading:opacity-75 block rounded-lg bg-dark border border-primary hover:bg-primary py-4 px-4 mt-3",
+        "phx-submit-loading:opacity-75 block rounded-lg bg-dark border border-primary hover:bg-primary py-4 px-4",
         "font-display tracking-wider text-xs text-primary hover:text-white ",
         @class
       ]}

--- a/lib/game_box_web/components/typography.ex
+++ b/lib/game_box_web/components/typography.ex
@@ -77,7 +77,12 @@ defmodule GameBoxWeb.Typography do
 
   def h4(assigns) do
     ~H"""
-    <h4 class={get_heading_classes("text-lg font-display tracking-wider", assigns)} {@rest}>
+    <h4
+      class={
+        get_heading_classes("text-md md:text-lg leading-loose font-display tracking-wider", assigns)
+      }
+      {@rest}
+    >
       <%= render_slot(@inner_block) || @label %>
     </h4>
     """

--- a/lib/game_box_web/components/typography.ex
+++ b/lib/game_box_web/components/typography.ex
@@ -24,7 +24,7 @@ defmodule GameBoxWeb.Typography do
     <h1
       class={
         get_heading_classes(
-          "text-4xl font-display tracking-wider text-transparent bg-clip-text bg-gradient-to-br from-white to-secondary-dark",
+          "text-3xl md:text-4xl font-display tracking-wider text-transparent bg-clip-text bg-gradient-to-br from-white to-secondary-dark",
           assigns
         )
       }

--- a/lib/game_box_web/live/arena_live.ex
+++ b/lib/game_box_web/live/arena_live.ex
@@ -52,8 +52,8 @@ defmodule GameBoxWeb.ArenaLive do
         <div class="w-full mb-12">
           <.card>
             <.card_content>
-              <div class="flex justify-start items-start">
-                <div class="w-1/2">
+              <div class="flex flex-col md:flex-row justify-start items-start">
+                <div class="w-full md:w-1/2">
                   <div class="md:border-r border-zinc-700 mr-6 pr-6">
                     <div class="font-display text-sm uppercase text-secondary tracking-wider ">
                       Arena Code
@@ -83,13 +83,19 @@ defmodule GameBoxWeb.ArenaLive do
                 </div>
                 <div>
                   <.p class="font-display tracking-wider uppercase text-xs !mb-0 !pb-2">
-                    Players Online:
+                    Players Online <span class="text-md">(8)</span>
                   </.p>
-                  <.ol>
+                  <.ol class="grid grid-cols-1 md:grid-cols-2 gap-x-12">
                     <li :for={player <- @all_players}>
                       <%= player.name %>
                       <%= check_if_host(Arena.get_host(@arena.arena_id), player.id) %>
                     </li>
+                    <li>Player 2</li>
+                    <li>Player 3</li>
+                    <li>Player 4</li>
+                    <li>Player 5</li>
+                    <li>Player 6</li>
+                    <li>Player 7</li>
                   </.ol>
                 </div>
               </div>
@@ -98,7 +104,7 @@ defmodule GameBoxWeb.ArenaLive do
         </div>
         <div class="flex flex-col md:flex-row">
           <div class="w-full">
-            <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-x-12 gap-y-12 mb-12">
+            <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-x-12 gap-y-12 mb-12">
               <%= for game <- @games do %>
                 <.card>
                   <.card_media :if={game.artwork} src={game.artwork} />

--- a/lib/game_box_web/live/arena_live.ex
+++ b/lib/game_box_web/live/arena_live.ex
@@ -54,7 +54,7 @@ defmodule GameBoxWeb.ArenaLive do
             <.card_content>
               <div class="flex flex-col md:flex-row md:mb-6 justify-start items-start">
                 <div class="w-full md:w-1/3  md:border-r md:border-zinc-700 mr-6">
-                  <.arena_code arena_id={@arena.arena_id} />
+                  <.arena_code arena_id={@arena.arena_id} uri={@uri.authority} />
                 </div>
                 <div class="w-2/3">
                   <div class="mb-6 pt-12 md:pt-0">
@@ -207,7 +207,7 @@ defmodule GameBoxWeb.ArenaLive do
                       <Heroicons.chevron_down solid class="h-5 w-5 stroke-current inline" />
                     </a>
                     <div class="pt-6 hidden" id="invite-friends">
-                      <.arena_code arena_id={@arena.arena_id} />
+                      <.arena_code arena_id={@arena.arena_id} uri={@uri.authority} />
                     </div>
                   </div>
                 </div>
@@ -245,6 +245,9 @@ defmodule GameBoxWeb.ArenaLive do
     <% end %>
     """
   end
+
+  def handle_params(_unsigned_params, uri, socket),
+    do: {:noreply, assign(socket, uri: URI.parse(uri))}
 
   def handle_event(
         "select_game",

--- a/lib/game_box_web/live/arena_live.ex
+++ b/lib/game_box_web/live/arena_live.ex
@@ -136,7 +136,7 @@ defmodule GameBoxWeb.ArenaLive do
                         />
                       </div>
                     <% end %>
-                    <%= if !can_start_game?(assigns) do %>
+                    <%= unless can_start_game?(assigns) do %>
                       <.p class="italic pr-2">
                         You don't have the right number of players for this game.
                       </.p>

--- a/lib/game_box_web/live/arena_live.ex
+++ b/lib/game_box_web/live/arena_live.ex
@@ -58,8 +58,8 @@ defmodule GameBoxWeb.ArenaLive do
                     <div class="font-display text-sm uppercase text-secondary tracking-wider ">
                       Arena Code
                     </div>
-                    <div class="flex justify-start items-center font-display gap-x-3 bg-dark my-3 ">
-                      <div class="text-primary text-2xl">
+                    <div class="flex justify-start items-center gap-x-3 bg-dark my-3 ">
+                      <div class="font-display text-primary text-2xl tracking-widest">
                         <span id="arena-code"><%= @arena.arena_id %></span>
                       </div>
                       <div>
@@ -72,7 +72,7 @@ defmodule GameBoxWeb.ArenaLive do
                         </.button>
                       </div>
                     </div>
-                    <div class="border-t border-zinc-700">
+                    <div class="border-t border-zinc-700 mt-3 pt-3">
                       <.p class="text-sm leading-4">
                         Have your friends enter this code at
                         <.link href="http://gamebox.fly.dev" target="_blank">gamebox.fly.dev</.link>
@@ -83,28 +83,27 @@ defmodule GameBoxWeb.ArenaLive do
                 </div>
                 <div>
                   <.p class="font-display tracking-wider uppercase text-xs !mb-0 !pb-2">
-                    Players Online <span class="text-md">(8)</span>
+                    Players Online <span class="text-md">(<%= @total_players %>)</span>
                   </.p>
                   <.ol class="grid grid-cols-1 md:grid-cols-2 gap-x-12">
                     <li :for={player <- @all_players}>
                       <%= player.name %>
                       <%= check_if_host(Arena.get_host(@arena.arena_id), player.id) %>
                     </li>
-                    <li>Player 2</li>
-                    <li>Player 3</li>
-                    <li>Player 4</li>
-                    <li>Player 5</li>
-                    <li>Player 6</li>
-                    <li>Player 7</li>
                   </.ol>
                 </div>
+              </div>
+              <div class="border-t border-zinc-700 text-center mt-6 md:mt-0">
+                <.p class="!text-primary pt-6 text-lg">
+                  <%= populate_hint(@game_selected, @is_host) %>
+                </.p>
               </div>
             </.card_content>
           </.card>
         </div>
         <div class="flex flex-col md:flex-row">
           <div class="w-full">
-            <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-x-12 gap-y-12 mb-12">
+            <div class="grid grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-x-6 gap-y-6 md:gap-x-12 md:gap-y-12 mb-12">
               <%= for game <- @games do %>
                 <.card>
                   <.card_media :if={game.artwork} src={game.artwork} />
@@ -141,11 +140,11 @@ defmodule GameBoxWeb.ArenaLive do
             <.h4 class="pl-4" label={@game_selected.title} />
           </div>
 
-          <div class="flex row gap-x-8 mt-8">
-            <div class="basis-2/3">
-              <img class="aspect-square" src={@game_selected.artwork} />
+          <div class="flex row gap-x-8 mt-8 grid grid-cols-6">
+            <div class="col-span-3">
+              <img class="w-1/2" src={@game_selected.artwork} />
               <div class="mt-12">
-                <.h4>How to play:</.h4>
+                <.h4>Game Description:</.h4>
                 <.p><%= @game_selected.description %></.p>
               </div>
               <.card class="mt-12">
@@ -160,11 +159,12 @@ defmodule GameBoxWeb.ArenaLive do
                 </.card_content>
               </.card>
             </div>
-            <div class="basis-1/3">
+            <div class="col-span-3">
               <.card>
                 <.card_content>
                   <div>
-                    <.h4 label="Details" />
+                    <.h4 label="Game Details" />
+
                     <.p>
                       Player Count: <%= get_player_count(
                         @constraints.min_players,
@@ -174,7 +174,7 @@ defmodule GameBoxWeb.ArenaLive do
                   </div>
                   <.card>
                     <.card_content>
-                      <.p class="font-display !text-white">Online Players</.p>
+                      <.p class="font-display !text-white">Players Online (<%= @total_players %>)</.p>
                       <.ol>
                         <li :for={player <- @all_players}>
                           <%= player.name %>
@@ -454,14 +454,15 @@ defmodule GameBoxWeb.ArenaLive do
     })
   end
 
-  defp populate_subtext(nil, true), do: "Select a game to get started!"
-  defp populate_subtext(nil, false), do: "Waiting for the host to select a game..."
-  defp populate_subtext(_, _), do: nil
+  defp populate_hint(nil, true), do: "Select a game from below to get started!"
+  defp populate_hint(nil, false), do: "Waiting for the host to select a game..."
+  defp populate_hint(_, _), do: nil
 
   defp get_player_count(min_players, max_players) when min_players == max_players, do: min_players
 
-  defp get_player_count(min_players, max_players) when min_players != max_players,
-    do: min_players <> "-" <> max_players
+  defp get_player_count(min_players, max_players) when min_players != max_players do
+    to_string(min_players) <> "-" <> to_string(max_players)
+  end
 
   defp check_if_host(arena_host, player_id) when arena_host == player_id, do: "(host)"
   defp check_if_host(arena_host, player_id) when arena_host !== player_id, do: ""

--- a/lib/game_box_web/live/arena_live.ex
+++ b/lib/game_box_web/live/arena_live.ex
@@ -89,7 +89,7 @@ defmodule GameBoxWeb.ArenaLive do
                   />
                   <.card_content
                     author={"@#{game.user.gh_login}"}
-                    author_link={"https://github.com/@#{game.user.gh_login}"}
+                    author_link={"https://github.com/#{game.user.gh_login}"}
                     heading={game.title}
                   />
                   <.card_footer>
@@ -114,7 +114,7 @@ defmodule GameBoxWeb.ArenaLive do
           <div class="flex">
             <div class="md:p-6 w-full">
               <div class="flex flex-col md:flex-row justify-start px-6 md:px-0 md:items-center py-6">
-                <div class="md:w-1/3">
+                <div class="md:w-2/3">
                   <div>
                     <.h5 class="inline" label="Game:" />
                     <.h4 class="!text-secondary inline" label={@game_selected.title} />
@@ -124,7 +124,7 @@ defmodule GameBoxWeb.ArenaLive do
                     <.h4 class="!text-secondary inline !text-xs" label={@arena.arena_id} />
                   </div>
                 </div>
-                <div class="w-full md:w-2/3 mb-3 md:pl-12">
+                <div class="w-full md:w-1/3 mb-3 md:pl-12">
                   <%= if @is_host && @game_selected do %>
                     <%= if can_start_game?(assigns) do %>
                       <div class="flex w-full gap-3">

--- a/lib/game_box_web/live/arena_live.ex
+++ b/lib/game_box_web/live/arena_live.ex
@@ -48,49 +48,84 @@ defmodule GameBoxWeb.ArenaLive do
 
     ~H"""
     <%= if board == "" do %>
-      <%!-- <.hero
-        subheader="Arena"
-        header={@arena.arena_id}
-        subtext={populate_subtext(@game_selected, @is_host)}
-      /> --%>
-      <div class="flex justify-center items-center">
-        Your Arena Code:
-        <span class="text-primary text-2xl" id="arena-code"><%= @arena.arena_id %></span>
-        <.button
-          phx-click={JS.dispatch("gamebox:clipcopy", to: "#arena-code")}
-          class="inline"
-          variant="outline"
-        >
-          COPY
-        </.button>
-      </div>
       <%= if is_nil(@game_selected) do %>
-        <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-x-12 gap-y-12 mb-12">
-          <%= for game <- @games do %>
-            <.card>
-              <.card_media :if={game.artwork} src={game.artwork} />
-              <.card_media
-                :if={!game.artwork}
-                src="/images/donut.png"
-                class="flex justify-center w-48 p-6"
-              />
-              <.card_content
-                author={"@#{game.user.gh_login}"}
-                author_link={"https://github.com/@#{game.user.gh_login}"}
-                heading={game.title}
-              />
-              <.card_footer>
-                <%= if @is_host do %>
-                  <.button
-                    phx-click="select_game"
-                    phx-value-game_id={game.id}
-                    label="Start"
-                    class="w-full"
+        <div class="w-full mb-12">
+          <.card>
+            <.card_content>
+              <div class="flex justify-start items-start">
+                <div class="w-1/2">
+                  <div class="md:border-r border-zinc-700 mr-6 pr-6">
+                    <div class="font-display text-sm uppercase text-secondary tracking-wider ">
+                      Arena Code
+                    </div>
+                    <div class="flex justify-start items-center font-display gap-x-3 bg-dark my-3 ">
+                      <div class="text-primary text-2xl">
+                        <span id="arena-code"><%= @arena.arena_id %></span>
+                      </div>
+                      <div>
+                        <.button
+                          phx-click={JS.dispatch("gamebox:clipcopy", to: "#arena-code")}
+                          class="inline"
+                          variant="outline"
+                        >
+                          COPY
+                        </.button>
+                      </div>
+                    </div>
+                    <div class="border-t border-zinc-700">
+                      <.p class="text-sm leading-4">
+                        Have your friends enter this code at
+                        <.link href="http://gamebox.fly.dev" target="_blank">gamebox.fly.dev</.link>
+                        to play games together!
+                      </.p>
+                    </div>
+                  </div>
+                </div>
+                <div>
+                  <.p class="font-display tracking-wider uppercase text-xs !mb-0 !pb-2">
+                    Players Online:
+                  </.p>
+                  <.ol>
+                    <li :for={player <- @all_players}>
+                      <%= player.name %>
+                      <%= check_if_host(Arena.get_host(@arena.arena_id), player.id) %>
+                    </li>
+                  </.ol>
+                </div>
+              </div>
+            </.card_content>
+          </.card>
+        </div>
+        <div class="flex flex-col md:flex-row">
+          <div class="w-full">
+            <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-x-12 gap-y-12 mb-12">
+              <%= for game <- @games do %>
+                <.card>
+                  <.card_media :if={game.artwork} src={game.artwork} />
+                  <.card_media
+                    :if={!game.artwork}
+                    src="/images/donut.png"
+                    class="flex justify-center w-48 p-6"
                   />
-                <% end %>
-              </.card_footer>
-            </.card>
-          <% end %>
+                  <.card_content
+                    author={"@#{game.user.gh_login}"}
+                    author_link={"https://github.com/@#{game.user.gh_login}"}
+                    heading={game.title}
+                  />
+                  <.card_footer>
+                    <%= if @is_host do %>
+                      <.button
+                        phx-click="select_game"
+                        phx-value-game_id={game.id}
+                        label="Start"
+                        class="w-full"
+                      />
+                    <% end %>
+                  </.card_footer>
+                </.card>
+              <% end %>
+            </div>
+          </div>
         </div>
       <% end %>
       <%= if @game_selected && !@game_started do %>
@@ -417,11 +452,11 @@ defmodule GameBoxWeb.ArenaLive do
   defp populate_subtext(nil, false), do: "Waiting for the host to select a game..."
   defp populate_subtext(_, _), do: nil
 
-  defp get_player_count(min_players, max_players) when min_players == max_players do
-    min_players
-  end
+  defp get_player_count(min_players, max_players) when min_players == max_players, do: min_players
 
-  defp get_player_count(min_players, max_players) when min_players != max_players do
-    min_players <> "-" <> max_players
-  end
+  defp get_player_count(min_players, max_players) when min_players != max_players,
+    do: min_players <> "-" <> max_players
+
+  defp check_if_host(arena_host, player_id) when arena_host == player_id, do: "(host)"
+  defp check_if_host(arena_host, player_id) when arena_host !== player_id, do: ""
 end

--- a/lib/game_box_web/live/arena_live.ex
+++ b/lib/game_box_web/live/arena_live.ex
@@ -52,12 +52,12 @@ defmodule GameBoxWeb.ArenaLive do
         <div class="w-full mb-6">
           <.card>
             <.card_content>
-              <div class="flex flex-col md:flex-row justify-start items-start">
-                <div class="w-1/3 border-r border-zinc-700 mr-6">
+              <div class="flex flex-col md:flex-row md:mb-6 justify-start items-start">
+                <div class="w-full md:w-1/3  md:border-r md:border-zinc-700 mr-6">
                   <.arena_code arena_id={@arena.arena_id} />
                 </div>
                 <div class="w-2/3">
-                  <div class="mb-6">
+                  <div class="mb-6 pt-12 md:pt-0">
                     <.p class="font-display tracking-wider uppercase text-xs !mt-0 !pt-0 !pb-2">
                       Players Online <span class="text-md">(<%= @total_players %>)</span>
                     </.p>
@@ -112,9 +112,9 @@ defmodule GameBoxWeb.ArenaLive do
       <%= if @game_selected && !@game_started do %>
         <div class="border border-zinc-700 rounded">
           <div class="flex">
-            <div class="p-6 w-full">
-              <div class="flex justify-start items-center py-6">
-                <div class="w-2/3">
+            <div class="md:p-6 w-full">
+              <div class="flex flex-col md:flex-row justify-start px-6 md:px-0 md:items-center py-6">
+                <div class="md:w-1/3">
                   <div>
                     <.h5 class="inline" label="Game:" />
                     <.h4 class="!text-secondary inline" label={@game_selected.title} />
@@ -124,7 +124,7 @@ defmodule GameBoxWeb.ArenaLive do
                     <.h4 class="!text-secondary inline !text-xs" label={@arena.arena_id} />
                   </div>
                 </div>
-                <div class="w-1/3 mb-3 pl-6">
+                <div class="w-full md:w-2/3 mb-3 md:pl-12">
                   <%= if @is_host && @game_selected do %>
                     <%= if can_start_game?(assigns) do %>
                       <div class="flex w-full gap-3">
@@ -151,11 +151,11 @@ defmodule GameBoxWeb.ArenaLive do
 
               <.divider />
 
-              <div class="flex w-full">
-                <div class="w-1/3">
-                  <img class="w-4/5" src={@game_selected.artwork} />
+              <div class="flex flex-col md:flex-row w-full p-6 md:p-0">
+                <div class="w-2/3 md:w-1/3">
+                  <img class="w-full md:w-4/5 pb-6 md:pb-0" src={@game_selected.artwork} />
                 </div>
-                <div class="w-1/3 border-r border-zinc-700">
+                <div class="w-full md:w-1/3 md:border-r md:border-zinc-700">
                   <div class="pr-12">
                     <.h4>Game Description:</.h4>
                     <.p>
@@ -176,9 +176,9 @@ defmodule GameBoxWeb.ArenaLive do
                     </div>
                   </div>
                 </div>
-                <div class="w-1/3">
-                  <div class="pl-12">
-                    <div class="pb-12">
+                <div class="w-full md:w-1/3">
+                  <div class="md:pl-12">
+                    <div class="border-t border-zinc-700 pt-6 mt-6 pb-12 md:pt-0 md:mt-0 md:border-0">
                       <.p class="font-display tracking-wider uppercase text-xs !mb-0 !pb-2">
                         Players Online <span class="text-md">(<%= @total_players %>)</span>
                       </.p>

--- a/lib/game_box_web/live/arena_live.ex
+++ b/lib/game_box_web/live/arena_live.ex
@@ -113,12 +113,15 @@ defmodule GameBoxWeb.ArenaLive do
                   <div>
                     <.h4 label="Details" />
                     <.p>
-                      Player count: <%= @total_players %> out of <%= @constraints.min_players %>-<%= @constraints.max_players %>
+                      Player Count: <%= get_player_count(
+                        @constraints.min_players,
+                        @constraints.max_players
+                      ) %>
                     </.p>
                   </div>
                   <.card>
                     <.card_content>
-                      <.p class="font-bold">Online Players</.p>
+                      <.p class="font-display !text-white">Online Players</.p>
                       <.ol>
                         <li :for={player <- @all_players}>
                           <%= player.name %>
@@ -127,7 +130,9 @@ defmodule GameBoxWeb.ArenaLive do
                     </.card_content>
                   </.card>
                   <%= unless can_start_game?(assigns) do %>
-                    <.p class="text-center">Waiting on more players...</.p>
+                    <.p class="text-center !text-primary font-display text-sm">
+                      Waiting on more players...
+                    </.p>
                   <% end %>
                 </.card_content>
                 <.card_footer>
@@ -399,4 +404,12 @@ defmodule GameBoxWeb.ArenaLive do
   defp populate_subtext(nil, true), do: "Select a game to get started!"
   defp populate_subtext(nil, false), do: "Waiting for the host to select a game..."
   defp populate_subtext(_, _), do: nil
+
+  defp get_player_count(min_players, max_players) when min_players == max_players do
+    min_players
+  end
+
+  defp get_player_count(min_players, max_players) when min_players != max_players do
+    min_players <> "-" <> max_players
+  end
 end

--- a/lib/game_box_web/live/arena_live.ex
+++ b/lib/game_box_web/live/arena_live.ex
@@ -5,6 +5,7 @@ defmodule GameBoxWeb.ArenaLive do
   alias GameBox.Arena
   alias GameBox.Games
   alias GameBox.Players
+  alias Phoenix.LiveView.JS
   alias Phoenix.PubSub
 
   def mount(%{"arena_id" => arena_id}, _session, %{assigns: %{player_id: player_id}} = socket) do
@@ -47,11 +48,22 @@ defmodule GameBoxWeb.ArenaLive do
 
     ~H"""
     <%= if board == "" do %>
-      <.hero
+      <%!-- <.hero
         subheader="Arena"
         header={@arena.arena_id}
         subtext={populate_subtext(@game_selected, @is_host)}
-      />
+      /> --%>
+      <div class="flex justify-center items-center">
+        Your Arena Code:
+        <span class="text-primary text-2xl" id="arena-code"><%= @arena.arena_id %></span>
+        <.button
+          phx-click={JS.dispatch("gamebox:clipcopy", to: "#arena-code")}
+          class="inline"
+          variant="outline"
+        >
+          COPY
+        </.button>
+      </div>
       <%= if is_nil(@game_selected) do %>
         <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-x-12 gap-y-12 mb-12">
           <%= for game <- @games do %>

--- a/lib/game_box_web/live/arena_live.ex
+++ b/lib/game_box_web/live/arena_live.ex
@@ -64,7 +64,7 @@ defmodule GameBoxWeb.ArenaLive do
                     <.ol class="grid grid-cols-1 md:grid-cols-2 gap-x-12">
                       <li :for={player <- @all_players}>
                         <%= player.name %>
-                        <%= check_if_host(Arena.get_host(@arena.arena_id), player.id) %>
+                        <%= check_if_host(@arena.host_id, player.id) %>
                       </li>
                     </.ol>
                   </div>
@@ -185,7 +185,7 @@ defmodule GameBoxWeb.ArenaLive do
                       <.ol class="grid grid-cols-1">
                         <li :for={player <- @all_players}>
                           <%= player.name %>
-                          <%= check_if_host(Arena.get_host(@arena.arena_id), player.id) %>
+                          <%= check_if_host(@arena.host_id, player.id) %>
                         </li>
                       </.ol>
                     </div>

--- a/lib/game_box_web/live/arena_live.ex
+++ b/lib/game_box_web/live/arena_live.ex
@@ -251,8 +251,6 @@ defmodule GameBoxWeb.ArenaLive do
         %{"game-id" => game_id},
         %{assigns: %{arena: %{arena_id: arena_id}}} = socket
       ) do
-    IO.inspect("hey girl you selected a game")
-
     case Arena.set_game(arena_id, game_id) do
       {:ok, _game_id} ->
         PubSub.broadcast(GameBox.PubSub, "arena:#{arena_id}", :game_selected)

--- a/lib/game_box_web/live/home_live.ex
+++ b/lib/game_box_web/live/home_live.ex
@@ -81,15 +81,6 @@ defmodule GameBoxWeb.HomeLive do
     {:noreply, socket}
   end
 
-  def handle_event(
-        "validate",
-        %{"arena_form" => arena_params},
-        %{assigns: %{changeset: changeset}} = socket
-      ) do
-    changeset = arena_params |> validate_arena(changeset) |> Map.put(:action, :validate)
-    {:noreply, assign(socket, :changeset, changeset)}
-  end
-
   @impl true
   def handle_event(
         "join_arena",

--- a/lib/game_box_web/live/home_live.ex
+++ b/lib/game_box_web/live/home_live.ex
@@ -11,7 +11,7 @@ defmodule GameBoxWeb.HomeLive do
   @impl true
   def render(assigns) do
     ~H"""
-    <.hero class="pt-16 !mb-0" header="Start or join an arena" />
+    <.hero class="pt-0 md:pt-16 !mb-0" header="Start or join an arena" />
     <div class="w-full flex justify-center">
       <.simple_form
         :let={f}

--- a/lib/game_box_web/live/home_live.ex
+++ b/lib/game_box_web/live/home_live.ex
@@ -9,6 +9,7 @@ defmodule GameBoxWeb.HomeLive do
     arena_id: :string
   }
   @impl true
+  @spec render(any) :: Phoenix.LiveView.Rendered.t()
   def render(assigns) do
     ~H"""
     <.hero class="pt-0 md:pt-16 !mb-0" header="Start or join an arena" />
@@ -64,6 +65,29 @@ defmodule GameBoxWeb.HomeLive do
       |> assign(:changeset, changeset)
 
     {:ok, socket}
+  end
+
+  @impl true
+  def handle_params(
+        %{"arena" => arena},
+        _url,
+        %{assigns: %{changeset: changeset}} = socket
+      ) do
+    changeset = %{"arena_id" => arena} |> validate_arena(changeset)
+    {:noreply, assign(socket, :changeset, changeset)}
+  end
+
+  def handle_params(_, _url, socket) do
+    {:noreply, socket}
+  end
+
+  def handle_event(
+        "validate",
+        %{"arena_form" => arena_params},
+        %{assigns: %{changeset: changeset}} = socket
+      ) do
+    changeset = arena_params |> validate_arena(changeset) |> Map.put(:action, :validate)
+    {:noreply, assign(socket, :changeset, changeset)}
   end
 
   @impl true

--- a/lib/game_box_web/live/styleguide/containers.html.heex
+++ b/lib/game_box_web/live/styleguide/containers.html.heex
@@ -145,7 +145,7 @@
         <.h5 label="Code Example:" />
         <.code content={code} />
       </div>
-      
+
       <div>
         <.h2 class="!text-primary">Card Media &lt;.card_media></.h2>
         <% attributes = """

--- a/lib/game_box_web/live/upload_live.ex
+++ b/lib/game_box_web/live/upload_live.ex
@@ -120,7 +120,7 @@ defmodule GameBoxWeb.UploadLive do
       </div>
 
       <.h2 label="My Games" class="mt-12" />
-      <div class="grid grid-cols-3 gap-x-12 gap-y-12 mb-12 mt-12">
+      <div class="grid grid-cols-2 md:grid-cols-4 gap-x-12 gap-y-12 mb-12 mt-12">
         <%= for game <- @games do %>
           <.card>
             <.card_media :if={game.artwork} src={game.artwork} />
@@ -129,6 +129,7 @@ defmodule GameBoxWeb.UploadLive do
               src="/images/donut.png"
               class="flex justify-center w-48 p-6"
             />
+
             <.card_content heading={game.title} />
           </.card>
         <% end %>

--- a/lib/game_box_web/router.ex
+++ b/lib/game_box_web/router.ex
@@ -39,6 +39,7 @@ defmodule GameBoxWeb.Router do
 
     live_session(:default, on_mount: GameBoxWeb.InitAssigns) do
       live("/", HomeLive)
+      live("/join", HomeLive)
       live("/arena/:arena_id", ArenaLive)
       live("/arena/:arena_id/game/:game_id", GameLive)
     end

--- a/lib/game_box_web/templates/layout/root.html.heex
+++ b/lib/game_box_web/templates/layout/root.html.heex
@@ -24,7 +24,7 @@
   </head>
   <body class="bg-dark bg-honeycomb-pattern bg-repeat-x bg-[length:100rem]">
     <div class="min-h-screen max-w-full bg-fixed bg-50% bg-gradient-to-t from-dark">
-      <div class="max-w-6xl mx-auto text-white p-10 lg:p-0">
+      <div class="max-w-6xl mx-auto text-white p-10 lg:p-6">
         <nav class="my-10">
           <div class="flex justify-between">
             <a href="/"><img src="/images/Gamebox-White.png" class="w-64" /></a>

--- a/test/game_box_web/live/arena_live_test.exs
+++ b/test/game_box_web/live/arena_live_test.exs
@@ -45,8 +45,8 @@ defmodule GameBoxWeb.ArenaLiveTest do
       {:ok, _view1, html1} = live(conn, ~p"/arena/#{arena_id}")
       {:ok, _view2, html2} = live(conn2, ~p"/arena/#{arena_id}")
 
-      assert html1 =~ "Select a game to get started!"
-      assert html2 =~ "Waiting for the host to select a game..."
+      assert html1 =~ "Select a game from below to get started!"
+      assert html2 =~ "Waiting for the host to select a game"
     end
 
     test "host can select and unselect a game", %{
@@ -81,10 +81,10 @@ defmodule GameBoxWeb.ArenaLiveTest do
       {:ok, view2, html2} = live(conn2, ~p"/arena/#{arena_id}")
 
       assert html1 =~ game.title
-      assert html1 =~ "Select a game to get started!"
+      assert html1 =~ "Select a game from below to get started!"
 
       assert html2 =~ game.title
-      refute html2 =~ "Select a game to get started!"
+      refute html2 =~ "Select a game from below to get started!"
 
       render_click(view1, :select_game, %{"game-id" => game.id})
 
@@ -105,9 +105,9 @@ defmodule GameBoxWeb.ArenaLiveTest do
       html2 = render(view2)
 
       assert html1 =~ game.title
-      assert html1 =~ "Select a game to get started!"
+      assert html1 =~ "Select a game from below to get started!"
       assert html2 =~ game.title
-      refute html2 =~ "Select a game to get started!"
+      refute html2 =~ "Select a game from below to get started!"
     end
 
     test "host can start game", %{
@@ -142,7 +142,7 @@ defmodule GameBoxWeb.ArenaLiveTest do
       {:ok, _view2, _html2} = live(conn2, ~p"/arena/#{arena_id}")
 
       assert html1 =~ game.title
-      assert html1 =~ "Select a game to get started!"
+      assert html1 =~ "Select a game from below to get started!"
 
       render_click(view1, :select_game, %{"game-id" => game.id})
       render_click(view1, :start_game, %{"game-id" => game.id})


### PR DESCRIPTION
The purpose of this PR is to do an overhaul of the Arena UI and UX. This includes content organization, thinking through the flow, etc. The desktop designs and functionality below have been reviewed and approved by @bhelx. 

## Implementation Notes 
- This adds a new `/join` path that accepts an arena param that will automatically populate in that field if you come from that link 

## Desktop 
![Screenshot 2023-02-28 at 11-59-38 Game Box](https://user-images.githubusercontent.com/65098991/221940618-413afc87-ae0a-4251-a787-71d9a411b1d7.png)
![Screenshot 2023-02-28 at 12-00-16 Game Box](https://user-images.githubusercontent.com/65098991/221940648-1d218e6f-2eb8-4cf8-86aa-ae8176758ec1.png)

## Mobile 
![Screenshot 2023-02-28 at 11-59-58 Game Box](https://user-images.githubusercontent.com/65098991/221940709-76d200e5-0166-43eb-94fc-a645b7321a4d.png)
![Screenshot 2023-02-28 at 12-00-07 Game Box](https://user-images.githubusercontent.com/65098991/221940754-849b22a5-67ad-4051-8457-71b4a4bd6f77.png)
