### PR TITLE
refactor: Remove Github signin from nav

### DIFF
--- a/lib/game_box_web/controllers/auth_controller.ex
+++ b/lib/game_box_web/controllers/auth_controller.ex
@@ -36,12 +36,12 @@ defmodule GameBoxWeb.AuthController do
     |> put_flash(:info, "Successfully authenticated #{user.gh_login}")
     |> put_session(:user_id, user.id)
     |> configure_session(renew: true)
-    |> redirect(to: ~p"/")
+    |> redirect(to: ~p"/upload")
   end
 
   defp handle_failure(conn) do
     conn
     |> put_flash(:error, "Failed to authenticate.")
-    |> redirect(to: ~p"/")
+    |> redirect(to: ~p"/signin")
   end
 end

--- a/lib/game_box_web/live/sign_in_live.ex
+++ b/lib/game_box_web/live/sign_in_live.ex
@@ -1,0 +1,15 @@
+defmodule GameBoxWeb.SignInLive do
+  use GameBoxWeb, :live_view
+
+  def render(assigns) do
+    ~H"""
+    <.hero header="Sign In" />
+    <div class="flex flex-col items-center justify-center">
+      <.p>
+        To upload a game, you must first sign in through Github. Click the link below to authorize GameBox.
+      </.p>
+      <.link class="text-primary" href={~p"/auth/github"}>Sign in with Github</.link>
+    </div>
+    """
+  end
+end

--- a/lib/game_box_web/live/sign_in_live.ex
+++ b/lib/game_box_web/live/sign_in_live.ex
@@ -8,7 +8,7 @@ defmodule GameBoxWeb.SignInLive do
       <.p>
         To upload a game, you must first sign in through Github. Click the link below to authorize GameBox.
       </.p>
-      <.link class="text-primary" href={~p"/auth/github"}>Sign in with Github</.link>
+      <.link class="text-primary text-xl" href={~p"/auth/github"}>Sign in with Github</.link>
     </div>
     """
   end

--- a/lib/game_box_web/live/sign_in_live.ex
+++ b/lib/game_box_web/live/sign_in_live.ex
@@ -4,7 +4,7 @@ defmodule GameBoxWeb.SignInLive do
   def render(assigns) do
     ~H"""
     <.hero header="Sign In" />
-    <div class="flex flex-col items-center justify-center">
+    <div class="flex flex-col items-center justify-center text-center">
       <.p>
         To upload a game, you must first sign in through Github. Click the link below to authorize GameBox.
       </.p>

--- a/lib/game_box_web/live/upload_live.ex
+++ b/lib/game_box_web/live/upload_live.ex
@@ -52,7 +52,7 @@ defmodule GameBoxWeb.UploadLive do
           phx-change="validate"
           phx-submit="upload_game"
         >
-          <div class="grid grid-cols-3 gap-6">
+          <div class="grid grid-cols-1 md:grid-cols-3 gap-6">
             <div class="col-span-2">
               <.input field={{f, :title}} label="Title" />
 

--- a/lib/game_box_web/live/upload_live.ex
+++ b/lib/game_box_web/live/upload_live.ex
@@ -36,6 +36,14 @@ defmodule GameBoxWeb.UploadLive do
     <.hero header="Upload a Game" />
     <div>
       <.h3 label="Tell us how to play your game" />
+      <div class="flex justify-between">
+        <.p>
+          Uploading as <%= @user.gh_login %>
+        </.p>
+        <.p>
+          <.link class="underline" href={~p"/auth/delete"}>Sign out with Github</.link>
+        </.p>
+      </div>
       <div>
         <.simple_form
           :let={f}

--- a/lib/game_box_web/plugs/require_auth.ex
+++ b/lib/game_box_web/plugs/require_auth.ex
@@ -14,7 +14,7 @@ defmodule GameBoxWeb.RequireAuth do
   def call(conn, _) do
     conn
     |> Controller.put_flash(:info, "You must be logged in to view this page.")
-    |> Controller.redirect(to: Routes.live_path(GameBoxWeb.Endpoint, GameBoxWeb.HomeLive))
+    |> Controller.redirect(to: Routes.live_path(GameBoxWeb.Endpoint, GameBoxWeb.SignInLive))
     |> halt()
   end
 end

--- a/lib/game_box_web/router.ex
+++ b/lib/game_box_web/router.ex
@@ -42,6 +42,7 @@ defmodule GameBoxWeb.Router do
       live("/join", HomeLive)
       live("/arena/:arena_id", ArenaLive)
       live("/arena/:arena_id/game/:game_id", GameLive)
+      live("/signin", SignInLive)
     end
   end
 

--- a/lib/game_box_web/views/layout_view.ex
+++ b/lib/game_box_web/views/layout_view.ex
@@ -18,22 +18,11 @@ defmodule GameBoxWeb.LayoutView do
         Home
       </.link>
     </li>
-    <%= if @current_user do %>
-      <li>
-        <.link href={~p"/upload"} class="hover:!text-primary">
-          Upload Game
-        </.link>
-      </li>
-      <li>
-        <.link href={~p"/auth/delete"} class="hover:!text-primary">Sign Out</.link>
-      </li>
-    <% else %>
-      <li>
-        <.link href={~p"/auth/github"} class="hover:!text-primary">
-          Sign in with Github
-        </.link>
-      </li>
-    <% end %>
+    <li>
+      <.link href={~p"/upload"} class="hover:!text-primary">
+        Upload Game
+      </.link>
+    </li>
     """
   end
 end

--- a/test/game_box_web/controllers/auth_controller_test.exs
+++ b/test/game_box_web/controllers/auth_controller_test.exs
@@ -20,7 +20,7 @@ defmodule GameBoxWeb.AuthControllerTest do
       assert Flash.get(conn.assigns.flash, :info) ==
                "Successfully authenticated #{gh_login}"
 
-      assert redirected_to(conn) == Routes.live_path(GameBoxWeb.Endpoint, GameBoxWeb.HomeLive)
+      assert redirected_to(conn) == Routes.live_path(GameBoxWeb.Endpoint, GameBoxWeb.UploadLive)
     end
 
     test "can handle a fail response from github", %{conn: conn} do
@@ -33,7 +33,7 @@ defmodule GameBoxWeb.AuthControllerTest do
 
       assert Flash.get(conn.assigns.flash, :error) == "Failed to authenticate."
 
-      assert redirected_to(conn) == Routes.live_path(GameBoxWeb.Endpoint, GameBoxWeb.HomeLive)
+      assert redirected_to(conn) == Routes.live_path(GameBoxWeb.Endpoint, GameBoxWeb.SignInLive)
     end
   end
 

--- a/test/game_box_web/live/upload_live_test.exs
+++ b/test/game_box_web/live/upload_live_test.exs
@@ -5,14 +5,14 @@ defmodule GameBoxWeb.UploadLiveTest do
 
   describe "mount" do
     test "redirects to sign in path when unauthenticated", %{conn: conn} do
-      welcome_path = Routes.live_path(GameBoxWeb.Endpoint, GameBoxWeb.SignInLive)
+      sign_in_path = Routes.live_path(GameBoxWeb.Endpoint, GameBoxWeb.SignInLive)
 
       assert {:error,
               {:redirect,
                %{
                  flash: %{"info" => "You must be logged in to view this page."},
-                 to: ^welcome_path
-               }}} = live(conn, Routes.live_path(GameBoxWeb.Endpoint, GameBoxWeb.SignInLive))
+                 to: ^sign_in_path
+               }}} = live(conn, Routes.live_path(GameBoxWeb.Endpoint, GameBoxWeb.UploadLive))
     end
 
     test "mounts to upload page when authenticated", %{conn: conn} do

--- a/test/game_box_web/live/upload_live_test.exs
+++ b/test/game_box_web/live/upload_live_test.exs
@@ -4,15 +4,15 @@ defmodule GameBoxWeb.UploadLiveTest do
   use GameBoxWeb.ConnCase
 
   describe "mount" do
-    test "redirects to welcome path when unauthenticated", %{conn: conn} do
-      welcome_path = Routes.live_path(GameBoxWeb.Endpoint, GameBoxWeb.HomeLive)
+    test "redirects to sign in path when unauthenticated", %{conn: conn} do
+      welcome_path = Routes.live_path(GameBoxWeb.Endpoint, GameBoxWeb.SignInLive)
 
       assert {:error,
               {:redirect,
                %{
                  flash: %{"info" => "You must be logged in to view this page."},
                  to: ^welcome_path
-               }}} = live(conn, Routes.live_path(GameBoxWeb.Endpoint, GameBoxWeb.UploadLive))
+               }}} = live(conn, Routes.live_path(GameBoxWeb.Endpoint, GameBoxWeb.SignInLive))
     end
 
     test "mounts to upload page when authenticated", %{conn: conn} do


### PR DESCRIPTION
## Background 
To eliminate confusion, it was requested that we remove the Github sign-in link from the navigation. Instead, we have an sign in page that you are directed to when you're not logged in if you attempt to go to the Upload Game screen. 

![Screenshot 2023-02-28 at 2 58 00 PM](https://user-images.githubusercontent.com/65098991/221978137-f5218b83-2afb-4a67-ac6a-58423d7587ab.png)
![Screenshot 2023-02-28 at 2 58 11 PM](https://user-images.githubusercontent.com/65098991/221978129-ff3d46aa-9295-431d-9787-50c988a4d752.png)