### PR TITLE
feat: tear down arena & player genservers

### DIFF
--- a/config/dev.exs
+++ b/config/dev.exs
@@ -30,6 +30,8 @@ config :game_box, GameBoxWeb.Endpoint,
     tailwind: {Tailwind, :install_and_run, [:default, ~w(--watch)]}
   ]
 
+config :game_box, tear_down_timeout: 3000
+
 # ## SSL Support
 #
 # In order to use HTTPS in development, a self-signed

--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -44,6 +44,9 @@ if config_env() == :prod do
 
   config :game_box, disk_volume_path: "/data"
 
+  config :game_box,
+    tear_down_timeout: String.to_integer(System.get_env("TEAR_DOWN_TIMEOUT") || "5000")
+
   # The secret key base is used to sign/encrypt cookies and other secrets.
   # A default value is used in config/dev.exs and config/test.exs but you
   # want to use a different value for prod and you most likely don't want

--- a/config/test.exs
+++ b/config/test.exs
@@ -24,6 +24,7 @@ config :game_box, GameBoxWeb.Endpoint,
 config :logger, level: :warn
 
 config :game_box, disk_volume_path: "test/uploads"
+config :game_box, tear_down_timeout: 50
 
 # Initialize plugs at runtime for faster test compilation
 config :phoenix, :plug_init_mode, :runtime

--- a/lib/game_box/arena.ex
+++ b/lib/game_box/arena.ex
@@ -303,15 +303,16 @@ defmodule GameBox.Arena do
   end
 
   @impl true
-  def terminate(:normal, state) do
-    state
-  end
+  def terminate(:normal, state), do: state
 
   @impl true
   def handle_info({:DOWN, _ref, :process, pid, _}, state) do
     pids = List.delete(state.pids, pid)
 
     if Enum.empty?(pids) do
+      # In the case that the pids are empty, we fire off a send_after
+      # to ensure that no players have required the view before
+      # gracefully shutting it down.
       timeout = Application.get_env(:game_box, :tear_down_timeout)
       Process.send_after(self(), :check_if_pids_still_empty, timeout)
     end

--- a/lib/game_box/arena.ex
+++ b/lib/game_box/arena.ex
@@ -116,6 +116,8 @@ defmodule GameBox.Arena do
   Start a new game or join an existing game.
   """
   def start(arena_id) do
+    arena_id = normalize_id(arena_id)
+
     case Horde.DynamicSupervisor.start_child(
            GameBox.DistributedSupervisor,
            {Arena, [arena_id: arena_id]}
@@ -310,7 +312,8 @@ defmodule GameBox.Arena do
     pids = List.delete(state.pids, pid)
 
     if Enum.empty?(pids) do
-      Process.send_after(self(), :check_if_pids_still_empty, 5000)
+      timeout = Application.get_env(:game_box, :tear_down_timeout)
+      Process.send_after(self(), :check_if_pids_still_empty, timeout)
     end
 
     {:noreply, Map.put(state, :pids, pids)}

--- a/lib/game_box/arena.ex
+++ b/lib/game_box/arena.ex
@@ -308,8 +308,15 @@ defmodule GameBox.Arena do
   @impl true
   def handle_info({:DOWN, _ref, :process, pid, _}, state) do
     pids = List.delete(state.pids, pid)
-    state = Map.put(state, :pids, pids)
 
+    if Enum.empty?(pids) do
+      Process.send_after(self(), :check_if_pids_still_empty, 5000)
+    end
+
+    {:noreply, Map.put(state, :pids, pids)}
+  end
+
+  def handle_info(:check_if_pids_still_empty, %{pids: pids} = state) do
     if Enum.empty?(pids) do
       {:stop, :normal, state}
     else

--- a/lib/game_box/players.ex
+++ b/lib/game_box/players.ex
@@ -186,7 +186,8 @@ defmodule GameBox.Players do
       |> Enum.empty?()
       |> case do
         true ->
-          Process.send_after(self(), :check_if_pids_still_empty, 5000)
+          timeout = Application.get_env(:game_box, :tear_down_timeout)
+          Process.send_after(self(), :check_if_pids_still_empty, timeout)
           {:noreply, players}
 
         _ ->

--- a/lib/game_box/players.ex
+++ b/lib/game_box/players.ex
@@ -180,7 +180,17 @@ defmodule GameBox.Players do
     else
       players = put_in(players, [player.id, :pids], List.delete(player.pids, pid))
 
-      {:noreply, players, {:continue, :broadcast}}
+      players
+      |> Map.values()
+      |> Enum.flat_map(&Map.get(&1, :pids))
+      |> Enum.empty?()
+      |> case do
+        true ->
+          {:stop, :normal, %{}}
+
+        _ ->
+          {:noreply, players, {:continue, :broadcast}}
+      end
     end
   end
 
@@ -247,6 +257,11 @@ defmodule GameBox.Players do
       _ ->
         {:error}
     end
+  end
+
+  @impl true
+  def terminate(:normal, state) do
+    state
   end
 
   @doc """

--- a/lib/game_box/players.ex
+++ b/lib/game_box/players.ex
@@ -186,11 +186,26 @@ defmodule GameBox.Players do
       |> Enum.empty?()
       |> case do
         true ->
-          {:stop, :normal, %{}}
+          Process.send_after(self(), :check_if_pids_still_empty, 5000)
+          {:noreply, players}
 
         _ ->
           {:noreply, players, {:continue, :broadcast}}
       end
+    end
+  end
+
+  def handle_info(:check_if_pids_still_empty, players) do
+    players
+    |> Map.values()
+    |> Enum.flat_map(&Map.get(&1, :pids))
+    |> Enum.empty?()
+    |> case do
+      true ->
+        {:stop, :normal, players}
+
+      _ ->
+        {:noreply, players}
     end
   end
 

--- a/lib/game_box/players.ex
+++ b/lib/game_box/players.ex
@@ -186,6 +186,9 @@ defmodule GameBox.Players do
       |> Enum.empty?()
       |> case do
         true ->
+          # In the case that the pids are empty, we fire off a send_after
+          # to ensure that no players have required the view before
+          # gracefully shutting it down.
           timeout = Application.get_env(:game_box, :tear_down_timeout)
           Process.send_after(self(), :check_if_pids_still_empty, timeout)
           {:noreply, players}
@@ -276,9 +279,7 @@ defmodule GameBox.Players do
   end
 
   @impl true
-  def terminate(:normal, state) do
-    state
-  end
+  def terminate(:normal, state), do: state
 
   @doc """
   Return the `:via` tuple for referencing and interacting with a specific Server.

--- a/lib/game_box_web/live/arena_live.ex
+++ b/lib/game_box_web/live/arena_live.ex
@@ -9,6 +9,8 @@ defmodule GameBoxWeb.ArenaLive do
   alias Phoenix.PubSub
 
   def mount(%{"arena_id" => arena_id}, _session, %{assigns: %{player_id: player_id}} = socket) do
+    arena_id = Arena.normalize_id(arena_id)
+
     if connected?(socket) do
       PubSub.subscribe(GameBox.PubSub, "arena:#{arena_id}")
       Players.monitor(arena_id, player_id)

--- a/lib/game_box_web/live/arena_live.ex
+++ b/lib/game_box_web/live/arena_live.ex
@@ -12,6 +12,7 @@ defmodule GameBoxWeb.ArenaLive do
     if connected?(socket) do
       PubSub.subscribe(GameBox.PubSub, "arena:#{arena_id}")
       Players.monitor(arena_id, player_id)
+      Arena.monitor(arena_id)
     end
 
     arena = Arena.exists?(arena_id)

--- a/lib/game_box_web/live/home_live.ex
+++ b/lib/game_box_web/live/home_live.ex
@@ -89,6 +89,7 @@ defmodule GameBoxWeb.HomeLive do
         %{assigns: %{player_id: player_id}} = socket
       ) do
     player_name = Players.format_name(player_name)
+    arena_id = Arena.normalize_id(arena_id)
 
     if Arena.exists?(arena_id) do
       case Players.start(arena_id) do

--- a/test/game_box_web/live/arena_live_test.exs
+++ b/test/game_box_web/live/arena_live_test.exs
@@ -5,6 +5,8 @@ defmodule GameBoxWeb.ArenaLiveTest do
   alias GameBox.Arena
   alias GameBox.Players
 
+  @arena_id "AAAA"
+
   setup do
     path = "tictactoe.wasm"
     disk_volume_path = Application.get_env(:game_box, :disk_volume_path)
@@ -27,27 +29,26 @@ defmodule GameBoxWeb.ArenaLiveTest do
         Phoenix.ConnTest.build_conn()
         |> Phoenix.ConnTest.init_test_session(%{player_id: Ecto.UUID.generate()})
 
-      arena_id = "AAAA"
       player_one_id = get_session(conn, :player_id)
       player_two_id = get_session(conn2, :player_id)
 
-      Arena.start(arena_id)
-      Arena.set_host(arena_id, player_one_id)
+      Arena.start(@arena_id)
+      Arena.set_host(@arena_id, player_one_id)
 
-      {:ok, _} = Players.start(arena_id)
+      {:ok, _} = Players.start(@arena_id)
 
-      Players.update_player(arena_id, player_one_id, %{
+      Players.update_player(@arena_id, player_one_id, %{
         name: "Test 1",
         joined_at: DateTime.utc_now() |> DateTime.to_unix()
       })
 
-      Players.update_player(arena_id, player_two_id, %{
+      Players.update_player(@arena_id, player_two_id, %{
         name: "Test 2",
         joined_at: DateTime.utc_now() |> DateTime.to_unix()
       })
 
-      {:ok, _view1, html1} = live(conn, ~p"/arena/#{arena_id}")
-      {:ok, _view2, html2} = live(conn2, ~p"/arena/#{arena_id}")
+      {:ok, _view1, html1} = live(conn, ~p"/arena/#{@arena_id}")
+      {:ok, _view2, html2} = live(conn2, ~p"/arena/#{@arena_id}")
 
       assert html1 =~ "Select a game from below to get started!"
       assert html2 =~ "Waiting for the host to select a game"
@@ -64,27 +65,26 @@ defmodule GameBoxWeb.ArenaLiveTest do
         Phoenix.ConnTest.build_conn()
         |> Phoenix.ConnTest.init_test_session(%{player_id: Ecto.UUID.generate()})
 
-      arena_id = "AAAA"
       player_one_id = get_session(conn, :player_id)
       player_two_id = get_session(conn2, :player_id)
 
-      Arena.start(arena_id)
-      Arena.set_host(arena_id, player_one_id)
+      Arena.start(@arena_id)
+      Arena.set_host(@arena_id, player_one_id)
 
-      {:ok, _} = Players.start(arena_id)
+      {:ok, _} = Players.start(@arena_id)
 
-      Players.update_player(arena_id, player_one_id, %{
+      Players.update_player(@arena_id, player_one_id, %{
         name: "Test 1",
         joined_at: DateTime.utc_now() |> DateTime.to_unix()
       })
 
-      Players.update_player(arena_id, player_two_id, %{
+      Players.update_player(@arena_id, player_two_id, %{
         name: "Test 2",
         joined_at: DateTime.utc_now() |> DateTime.to_unix()
       })
 
-      {:ok, view1, html1} = live(conn, ~p"/arena/#{arena_id}")
-      {:ok, view2, html2} = live(conn2, ~p"/arena/#{arena_id}")
+      {:ok, view1, html1} = live(conn, ~p"/arena/#{@arena_id}")
+      {:ok, view2, html2} = live(conn2, ~p"/arena/#{@arena_id}")
 
       assert html1 =~ game.title
       assert html1 =~ "Select a game from below to get started!"
@@ -127,27 +127,26 @@ defmodule GameBoxWeb.ArenaLiveTest do
         Phoenix.ConnTest.build_conn()
         |> Phoenix.ConnTest.init_test_session(%{player_id: Ecto.UUID.generate()})
 
-      arena_id = "AAAA"
       player_one_id = get_session(conn, :player_id)
       player_two_id = get_session(conn2, :player_id)
 
-      Arena.start(arena_id)
-      Arena.set_host(arena_id, player_one_id)
+      Arena.start(@arena_id)
+      Arena.set_host(@arena_id, player_one_id)
 
-      {:ok, _} = Players.start(arena_id)
+      {:ok, _} = Players.start(@arena_id)
 
-      Players.update_player(arena_id, player_one_id, %{
+      Players.update_player(@arena_id, player_one_id, %{
         name: "Test 1",
         joined_at: DateTime.utc_now() |> DateTime.to_unix()
       })
 
-      Players.update_player(arena_id, player_two_id, %{
+      Players.update_player(@arena_id, player_two_id, %{
         name: "Test 2",
         joined_at: DateTime.utc_now() |> DateTime.to_unix()
       })
 
-      {:ok, view1, html1} = live(conn, ~p"/arena/#{arena_id}")
-      {:ok, _view2, _html2} = live(conn2, ~p"/arena/#{arena_id}")
+      {:ok, view1, html1} = live(conn, ~p"/arena/#{@arena_id}")
+      {:ok, _view2, _html2} = live(conn2, ~p"/arena/#{@arena_id}")
 
       assert html1 =~ game.title
       assert html1 =~ "Select a game from below to get started!"

--- a/test/game_box_web/live/home_live_test.exs
+++ b/test/game_box_web/live/home_live_test.exs
@@ -1,20 +1,23 @@
 defmodule GameBoxWeb.HomeLiveTest do
   use GameBoxWeb.ConnCase
+  alias GameBox.Arena
 
   describe "home" do
     test "join an arena", ctx do
       %{conn: conn} = ctx
       {:ok, view, _html} = live(conn, Routes.live_path(GameBoxWeb.Endpoint, GameBoxWeb.HomeLive))
       player_id = get_session(conn, :player_id)
+      arena_id = "abcd"
+      Arena.start(arena_id)
 
       view
       |> element("#join_arena")
-      |> render_submit(%{arena_form: %{player_name: "Joe", arena_id: "abcd"}})
+      |> render_submit(%{arena_form: %{player_name: "Joe", arena_id: arena_id}})
 
       path = ~p"/arena/abcd"
       assert {^path, %{}} = assert_redirect(view)
-      assert %{id: ^player_id, name: "JOE"} = GameBox.Players.get_player("ABCD", player_id)
-      assert %{arena_id: "ABCD"} = GameBox.Arena.state("ABCD")
+      assert %{id: ^player_id, name: "JOE"} = GameBox.Players.get_player(arena_id, player_id)
+      assert %{arena_id: ^arena_id} = GameBox.Arena.state(arena_id)
     end
   end
 end

--- a/test/game_box_web/live/home_live_test.exs
+++ b/test/game_box_web/live/home_live_test.exs
@@ -2,7 +2,15 @@ defmodule GameBoxWeb.HomeLiveTest do
   use GameBoxWeb.ConnCase
   alias GameBox.Arena
 
-  alias GameBox.Arena
+  @arena_id "AAAA"
+
+  setup do
+    on_exit(fn ->
+      # We sleep at the end of each test to allow the genservers to get torn down. This value correlates to
+      # the 'tear_down_timeout' set in test.exs
+      :timer.sleep(50)
+    end)
+  end
 
   describe "home" do
     test "join an arena when it does not exist", %{conn: conn} do
@@ -10,27 +18,27 @@ defmodule GameBoxWeb.HomeLiveTest do
 
       assert view
              |> element("#join_arena")
-             |> render_submit(%{arena_form: %{player_name: "Matt", arena_id: "AAAA"}}) =~
+             |> render_submit(%{arena_form: %{player_name: "Matt", arena_id: "ABCD"}}) =~
                "Oops! That arena does not exist."
     end
 
     test "join an arena when it does exist", %{conn: conn} do
-      assert {:ok, :initiated} = Arena.start("BBBB")
-      assert %{arena_id: "bbbb"} = GameBox.Arena.state("BBBB")
+      assert {:ok, :initiated} = Arena.start(@arena_id)
+      assert %{arena_id: "aaaa"} = GameBox.Arena.state(@arena_id)
 
       {:ok, view, _html} = live(conn, Routes.live_path(GameBoxWeb.Endpoint, GameBoxWeb.HomeLive))
 
       player_id = get_session(conn, :player_id)
-      arena_id = "abcd"
-      Arena.start(arena_id)
 
       view
       |> element("#join_arena")
-      |> render_submit(%{arena_form: %{player_name: "Joe", arena_id: "Bbbb"}})
+      |> render_submit(%{arena_form: %{player_name: "Joe", arena_id: @arena_id}})
 
-      path = ~p"/arena/bbbb"
+      path = ~p"/arena/aaaa"
       assert assert_redirect(view, path)
-      assert %{id: ^player_id, name: "JOE"} = GameBox.Players.get_player("BBBB", player_id)
+      assert %{id: ^player_id, name: "JOE"} = GameBox.Players.get_player(@arena_id, player_id)
+
+      live(conn, ~p"/")
     end
   end
 end

--- a/test/game_box_web/live/home_live_test.exs
+++ b/test/game_box_web/live/home_live_test.exs
@@ -2,22 +2,35 @@ defmodule GameBoxWeb.HomeLiveTest do
   use GameBoxWeb.ConnCase
   alias GameBox.Arena
 
+  alias GameBox.Arena
+
   describe "home" do
-    test "join an arena", ctx do
-      %{conn: conn} = ctx
+    test "join an arena when it does not exist", %{conn: conn} do
       {:ok, view, _html} = live(conn, Routes.live_path(GameBoxWeb.Endpoint, GameBoxWeb.HomeLive))
+
+      assert view
+             |> element("#join_arena")
+             |> render_submit(%{arena_form: %{player_name: "Matt", arena_id: "AAAA"}}) =~
+               "Oops! That arena does not exist."
+    end
+
+    test "join an arena when it does exist", %{conn: conn} do
+      assert {:ok, :initiated} = Arena.start("BBBB")
+      assert %{arena_id: "bbbb"} = GameBox.Arena.state("BBBB")
+
+      {:ok, view, _html} = live(conn, Routes.live_path(GameBoxWeb.Endpoint, GameBoxWeb.HomeLive))
+
       player_id = get_session(conn, :player_id)
       arena_id = "abcd"
       Arena.start(arena_id)
 
       view
       |> element("#join_arena")
-      |> render_submit(%{arena_form: %{player_name: "Joe", arena_id: arena_id}})
+      |> render_submit(%{arena_form: %{player_name: "Joe", arena_id: "Bbbb"}})
 
-      path = ~p"/arena/abcd"
-      assert {^path, %{}} = assert_redirect(view)
-      assert %{id: ^player_id, name: "JOE"} = GameBox.Players.get_player(arena_id, player_id)
-      assert %{arena_id: ^arena_id} = GameBox.Arena.state(arena_id)
+      path = ~p"/arena/bbbb"
+      assert assert_redirect(view, path)
+      assert %{id: ^player_id, name: "JOE"} = GameBox.Players.get_player("BBBB", player_id)
     end
   end
 end


### PR DESCRIPTION
- feat: extends players.ex logic to send a stop event when all players have no pids remaining
- feat: implements similar monitor logic in arena.ex to track down events and stop servers when no longer in use
- fix: adds additional places where we should normalize the arena_id to fix a bug around subscribing to the wrong topic